### PR TITLE
bootstrap/nailgun minor cleanup

### DIFF
--- a/bootstrap_scala/BootstrapScala.java
+++ b/bootstrap_scala/BootstrapScala.java
@@ -1,105 +1,79 @@
-import java.io.*;
-import java.lang.reflect.*;
-import java.math.*;
-import java.net.*;
-import java.nio.*;
-import java.nio.file.*;
-import java.security.*;
-import java.util.*;
-import java.util.stream.*;
-import javax.tools.*;
+import java.io.File;
+import java.io.InputStream;
+import java.io.IOException;
+import java.net.MalformedURLException;
+import java.net.URL;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.nio.file.StandardCopyOption;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+import java.util.Arrays;
 import javax.xml.bind.annotation.adapters.HexBinaryAdapter;
 
-/*
-This file class allows bootstrapping out of Java into Scala.
-It downloads the Scala jars for the version number given as the first
-argument into the directory given as the second argument and returns
-a classpath String.
-*/
-public class BootstrapScala{
-	public final static Dependency[] dependencies(String target, String scalaVersion){
-		return new Dependency[]{
-			Dependency.scala(target, scalaVersion, "library", "f75e7acabd57b213d6f61483240286c07213ec0e"),
-			Dependency.scala(target, scalaVersion, "compiler","1454c21d39a4d991006a2a47c164f675ea1dafaf"),
-			Dependency.scala(target, scalaVersion, "reflect", "bf1649c9d33da945dea502180855b56caf06288c"),
-			new Dependency(target, "modules/scala-xml_2.11/1.0.5", "scala-xml_2.11-1.0.5", "77ac9be4033768cf03cc04fbd1fc5e5711de2459")
-		};
-	}
+/**
+ * This file class allows bootstrapping out of Java into Scala. It downloads the Scala jars for the
+ * version number given as the first argument into the directory given as the second argument and
+ * returns a classpath String.
+ */
+public class BootstrapScala {
 
-	public static void main(String args[]){
-		if(args.length < 2){
-			System.err.println("Usage: bootstrap_scala <scala version> <download directory>");
-			System.exit(1);
-		}
-		Dependency[] ds = dependencies( args[1], args[0] );
+  public final static Dependency[] dependencies(String target, String scalaVersion) throws MalformedURLException {
+    return new Dependency[] {
+      Dependency.scala(target, scalaVersion, "library", "f75e7acabd57b213d6f61483240286c07213ec0e"),
+      Dependency.scala(target, scalaVersion, "compiler","1454c21d39a4d991006a2a47c164f675ea1dafaf"),
+      Dependency.scala(target, scalaVersion, "reflect", "bf1649c9d33da945dea502180855b56caf06288c"),
+      new Dependency(target, "modules/scala-xml_2.11/1.0.5", "scala-xml_2.11-1.0.5", "77ac9be4033768cf03cc04fbd1fc5e5711de2459")
+    };
+  }
 
-		try {
-			new File(args[1]).mkdirs();
-			Arrays.stream(ds).forEach( d -> {
-				download( d.url, d.path, d.hash );
-			});
-			System.out.println(
-				String.join(
-					File.pathSeparator,
-					Arrays.stream(ds).map( d -> d.path.toString() ).toArray(String[]::new)
-				)
-			);
-		} catch (final Exception e) {
-		   throw new RuntimeException(e);
-		}
-	}
-	public static void download(URL urlString, Path target, String sha1){
-		try {
-			final Path unverified = Paths.get(target+".unverified");
+  public static void main(String args[]) throws IOException, NoSuchAlgorithmException {
+  
+    if(args.length < 2){
+      System.err.println("Usage: bootstrap_scala <scala version> <download directory>");
+      System.exit(1);
+    }
+  
+    Dependency[] ds = dependencies( args[1], args[0] );
+    new File(args[1]).mkdirs();
+    for (Dependency d: ds) {
+      download( d.url, d.path, d.hash );
+    }
 
-			if(!Files.exists(target)){
-				new File(target.toString()).getParentFile().mkdirs();
-				System.err.println("downloading "+urlString);
-				System.err.println("to "+target);
-				InputStream stream = urlString.openStream();
-				Files.copy(stream, unverified, StandardCopyOption.REPLACE_EXISTING);
-				stream.close();
-				String checksum = sha1(Files.readAllBytes(unverified));
-				if(sha1 == null || sha1.toUpperCase().equals(checksum)){
-					Files.move(unverified, target, StandardCopyOption.REPLACE_EXISTING, StandardCopyOption.ATOMIC_MOVE);
-				} else {
-					System.err.println(target + " checksum does not match.\nExpected: |"+sha1+"|\nFound:    |"+checksum+"|");
-					System.exit(1);
-				}
-			}
-		} catch (final Exception e) {
-		   throw new RuntimeException(e);
-		}
-	}
-	public static String sha1(byte[] bytes){
-		try {
-			final MessageDigest sha1 = MessageDigest.getInstance("SHA1");
-			sha1.update( bytes, 0, bytes.length );
-			return (new HexBinaryAdapter()).marshal(sha1.digest());
-		} catch (final Exception e) {
-		   throw new RuntimeException(e);
-		}
-	}
+    System.out.println(
+      String.join(
+        File.pathSeparator,
+        Arrays.stream(ds).map(d -> d.path.toString()).toArray(String[]::new)
+      )
+    );
+
+  }
+
+  public static void download(URL urlString, Path target, String sha1) throws IOException, NoSuchAlgorithmException {
+    final Path unverified = Paths.get(target+".unverified");
+    if(!Files.exists(target)) {
+      new File(target.toString()).getParentFile().mkdirs();
+      System.err.println("downloading " + urlString);
+      System.err.println("to " + target);
+      final InputStream stream = urlString.openStream();
+      Files.copy(stream, unverified, StandardCopyOption.REPLACE_EXISTING);
+      stream.close();
+      final String checksum = sha1(Files.readAllBytes(unverified));
+      if(sha1 == null || sha1.toUpperCase().equals(checksum)) {
+        Files.move(unverified, target, StandardCopyOption.REPLACE_EXISTING, StandardCopyOption.ATOMIC_MOVE);
+      } else {
+        System.err.println(target + " checksum does not match.\nExpected: |" + sha1 + "|\nFound:    |" + checksum + "|");
+        System.exit(1);
+      }
+    }
+  }
+
+  public static String sha1(byte[] bytes) throws NoSuchAlgorithmException {
+    final MessageDigest sha1 = MessageDigest.getInstance("SHA1");
+    sha1.update(bytes, 0, bytes.length);
+    return (new HexBinaryAdapter()).marshal(sha1.digest());
+  }
+
 }
 
-
-class Dependency{
-	URL url;
-	Path path;
-	String hash;
-	public Dependency(String target, String folder, String file, String hash){
-		path = Paths.get(target+file+".jar");
-		try { url = new URL("https://repo1.maven.org/maven2/org/scala-lang/"+folder+"/"+file+".jar"); }
-		catch (final MalformedURLException e) { throw new RuntimeException(e); }
-		hash = hash;
-	}
-	// scala-lang dependency
-	public static Dependency scala(String target, String scalaVersion, String scalaModule, String hash){
-		return new Dependency(
-			target,
-			"scala-"+scalaModule+"/"+scalaVersion,
-			"scala-"+scalaModule+"-"+scalaVersion,
-			hash
-		);
-	}
-}

--- a/bootstrap_scala/Dependency.java
+++ b/bootstrap_scala/Dependency.java
@@ -1,0 +1,29 @@
+import java.net.MalformedURLException;
+import java.net.URL;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+
+class Dependency {
+
+  final URL    url;
+  final Path   path;
+  final String hash;
+
+  public Dependency(String target, String folder, String file, String hash) throws MalformedURLException {
+    this.path = Paths.get(target + file + ".jar");
+    this.url  = new URL("https://repo1.maven.org/maven2/org/scala-lang/" + folder + "/" + file + ".jar");
+    this.hash = hash;
+  }
+
+  // scala-lang dependency
+  public static Dependency scala(String target, String scalaVersion, String scalaModule, String hash) 
+    throws MalformedURLException {
+    return new Dependency(
+      target,
+      "scala-" + scalaModule + "/" + scalaVersion,
+      "scala-" + scalaModule + "-" + scalaVersion,
+      hash
+    );
+  }
+
+}

--- a/nailgun_launcher/NailgunLauncher.java
+++ b/nailgun_launcher/NailgunLauncher.java
@@ -7,42 +7,55 @@ import java.nio.file.*;
 import java.util.*;
 import java.util.concurrent.ConcurrentHashMap;
 
-/*
-This launcher allows to use Nailgun without loading anything else permanenetly into it's classpath.
-The main method loads the given class from the given class math, calls it's main methods passing
-in the additional arguments.
-*/
+/** 
+ * This launcher allows to use Nailgun without loading anything else permanenetly into its
+ * classpath. The main method loads the given class from the given class math, calls it's main
+ * methods passing in the additional arguments.
+ */
 public class NailgunLauncher{
-	/* Persistent cache for caching classloaders for the JVM life time.
-	   Can be used as needed by user code to improve startup time. */
-	public static ConcurrentHashMap<String,ClassLoader> classLoaderCache = new ConcurrentHashMap<String,ClassLoader>();
-	public static void main(String[] args){
-		try{
-			if(args.length < 3){
-				System.out.println("usage: <main class> <class path> <... args>");
-			} else {
-				URLClassLoader cl = new URLClassLoader( // TODO: cache this classloader, but invalidate on changes
-					Arrays.stream(
-						args[1].split(File.pathSeparator)
-					).filter( cp -> !(cp == "") ).map( cp -> {
-						try { return new URL("file:" + cp); }
-						catch(MalformedURLException e) { throw new RuntimeException(e); }
-					}).toArray(URL[]::new)
-				){
-					public String toString(){
-						String suffix = "";
-						if(getParent() != ClassLoader.getSystemClassLoader())
-							suffix = ", "+getParent();
-						return "URLClassLoader(" + Arrays.toString(getURLs()) + suffix +")";
-					}
-				};
-				cl  .loadClass( args[0] )
-					.getMethod( "main", String[].class )
-					.invoke(
-						null/* _cls.newInstance()*/,
-						(Object) Arrays.stream(args).skip(2).toArray( String[]::new )
-					);
-			}
-		} catch (Exception e) { throw new RuntimeException(e); }
-	}
+
+  /** 
+   * Persistent cache for caching classloaders for the JVM life time. Can be used as needed by user
+   * code to improve startup time. 
+   */
+  public static ConcurrentHashMap<String,ClassLoader> classLoaderCache = 
+    new ConcurrentHashMap<String,ClassLoader>();
+
+  public static void main(String[] args) throws ClassNotFoundException, 
+                                                NoSuchMethodException, 
+                                                IllegalAccessException, 
+                                                InvocationTargetException {
+    if (args.length < 3) {
+
+      System.out.println("usage: <main class> <class path> <... args>");
+    
+    } else {
+
+      // TODO: cache this classloader, but invalidate on changes
+      final URL[] urls = 
+        Arrays.stream(
+          args[1].split(File.pathSeparator)
+        ).filter( cp -> !(cp == "") ).map( cp -> {
+          try { return new URL("file:" + cp); }
+          catch(MalformedURLException e) { throw new RuntimeException(e); }
+        }).toArray(URL[]::new);
+
+      URLClassLoader cl = new URLClassLoader(urls) {
+        public String toString() {
+          String suffix = "";
+          if (getParent() != ClassLoader.getSystemClassLoader())
+            suffix = ", "+getParent();
+          return "URLClassLoader(" + Arrays.toString(getURLs()) + suffix +")";
+        }
+      };
+
+      cl.loadClass(args[0])
+        .getMethod("main", String[].class)
+        .invoke(
+          null/* _cls.newInstance()*/,
+          (Object) Arrays.stream(args).skip(2).toArray(String[]::new)
+        );
+
+    }
+  }
 }


### PR DESCRIPTION
A few minor changes.

- whitespace, etc., for readability
- move `Dependency` into its own compilation unit
- propagate checked exceptions rather than wrapping

For Java code I prefer to propagate checked exceptions in the method types rather than wrapping them in `RuntimeException` or simply marking everything as `throws Exception`. As code evolves this helps prevent inadvertent propagation of exceptions that can actually be handled; the programmer gets no indication due to the outer catch-all.