### PR TITLE
The condition disables zinc too eagerly, which can easily

### DIFF
--- a/stage1/Stage1Lib.scala
+++ b/stage1/Stage1Lib.scala
@@ -130,7 +130,7 @@ class Stage1Lib( val logger: Logger ){
 
     // only run zinc if files changed, for performance reasons
     // FIXME: this is broken, need invalidate on changes in dependencies as well
-    if( /*true || */ needsRecompile ){
+    if( true || needsRecompile ){
       val zinc = MavenDependency("com.typesafe.zinc","zinc", zincVersion)(logger)
       val zincDeps = zinc.transitiveDependencies
 


### PR DESCRIPTION
lead to half compiled sets of class files after a type
error and no attempt to re-compile unless a source file
is changed.

This workaround fixes it but needs to run zinc more often
which comes with a roughly 0.1 seconds time penalty every
time (despite classloader caching) for every involved sub build.

A fix would trep zinc's exit code (or call zinc differently)
in order to determine if it succeeded and if it did not
do something that makes it run again the next time, like
deleting the class files or touching a source file.
Probably there is a better way.