### PR TITLE
Various exit code related fixes.

### DIFF
--- a/stage1/Stage1Lib.scala
+++ b/stage1/Stage1Lib.scala
@@ -131,7 +131,7 @@ class Stage1Lib( val logger: Logger ) extends BaseLib{
 
     // only run zinc if files changed, for performance reasons
     // FIXME: this is broken, need invalidate on changes in dependencies as well
-    if( true || needsRecompile ){
+    if( needsRecompile ){
       val zinc = MavenDependency("com.typesafe.zinc","zinc", zincVersion)(logger)
       val zincDeps = zinc.transitiveDependencies
 

--- a/stage2/BasicBuild.scala
+++ b/stage2/BasicBuild.scala
@@ -20,7 +20,7 @@ class Build(val context: Context) extends Dependency with TriggerLoop{
   // library available to builds
   implicit final val logger: Logger = context.logger
   override final protected val lib: Lib = new Lib(logger)
-  
+
   // ========== general stuff ==========
 
   def enableConcurrency = false
@@ -95,7 +95,7 @@ class Build(val context: Context) extends Dependency with TriggerLoop{
   )
 
   def triggerLoopFiles: Seq[File] = sources ++ transitiveDependencies.collect{ case b: TriggerLoop => b.triggerLoopFiles }.flatten
-  
+
   def localJars           : Seq[File] =
     Seq(projectDirectory ++ "/lib")
       .filter(_.exists)
@@ -133,7 +133,7 @@ class Build(val context: Context) extends Dependency with TriggerLoop{
     }
     sourcesChanged || transitiveDependencies.map(_.updated).fold(false)(_ || _)
   }
- 
+
   private object cacheCompileBasicBuild extends Cache[File]
   def compile: File = cacheCompileBasicBuild{
     //println(transitiveDependencies.filter(_.updated).mkString("\n"))

--- a/stage2/BasicBuild.scala
+++ b/stage2/BasicBuild.scala
@@ -145,7 +145,7 @@ class Build(val context: Context) extends Dependency with TriggerLoop{
   }
 
   def runClass: String = "Main"
-  def run: ExitCode = lib.runMainIfFound( runClass, context.args, classLoader ) 
+  def run: ExitCode = lib.runMainIfFound( runClass, context.args, classLoader )
 
   def test: ExitCode = lib.test(context)
 

--- a/stage2/Lib.scala
+++ b/stage2/Lib.scala
@@ -25,7 +25,7 @@ final class Lib(logger: Logger) extends Stage1Lib(logger) with Scaffold{
 
   val buildClassName = "Build"
   val buildBuildClassName = "BuildBuild"
-  
+
   /** Loads Build for given Context */
   def loadDynamic(context: Context, default: Context => Build = new Build(_)): Build = {
     context.logger.composition( context.logger.showInvocation("Build.loadDynamic",context) )
@@ -37,7 +37,7 @@ final class Lib(logger: Logger) extends Stage1Lib(logger) with Scaffold{
   */
   def loadRoot(context: Context, default: Context => Build = new Build(_)): Build = {
     context.logger.composition( context.logger.showInvocation("Build.loadRoot",context) )
-    def findStartDir(cwd: File): File = {    
+    def findStartDir(cwd: File): File = {
       val buildDir = realpath( cwd ++ "/build" )
       if(buildDir.exists) findStartDir(buildDir) else cwd
     }
@@ -59,7 +59,7 @@ final class Lib(logger: Logger) extends Stage1Lib(logger) with Scaffold{
     updated: Boolean,
     sourceFiles: Seq[File], compileTarget: File, dependenyClasspath: ClassPath,
     compileArgs: Seq[String], zincVersion: String, scalaVersion: String
-  ): File = {    
+  ): File = {
     if(sourceFiles.nonEmpty)
       lib.zinc(
         updated, sourceFiles, compileTarget, dependenyClasspath, compileArgs
@@ -90,7 +90,7 @@ final class Lib(logger: Logger) extends Stage1Lib(logger) with Scaffold{
     compileArgs: Seq[String]
   ): File = {
     mkdir(Path(apiTarget))
-    if(sourceFiles.nonEmpty){    
+    if(sourceFiles.nonEmpty){
       val args = Seq(
         // FIXME: can we use compiler dependency here?
         "-cp", dependencyClasspath.string, // FIXME: does this break for builds that don't have scalac dependencies?
@@ -98,7 +98,7 @@ final class Lib(logger: Logger) extends Stage1Lib(logger) with Scaffold{
       ) ++ compileArgs ++ sourceFiles.map(_.toString)
       logger.lib("creating docs for source files "+args.mkString(", "))
       trapExitCode{
-        redirectOutToErr{        
+        redirectOutToErr{
           runMain(
             "scala.tools.nsc.ScalaDoc",
             args,
@@ -123,7 +123,7 @@ final class Lib(logger: Logger) extends Stage1Lib(logger) with Scaffold{
       context.copy( cwd = context.cwd ++ "/test", args = loggerArg.toVector ++ context.args ),
       new Build(_) with mixins.Test
     ).run
-    logger.lib(s"return testDefault( $context )")    
+    logger.lib(s"return testDefault( $context )")
     exitCode
   }
 
@@ -223,7 +223,7 @@ final class Lib(logger: Logger) extends Stage1Lib(logger) with Scaffold{
         jar.closeEntry
         name
     }
-    
+
     val duplicateFiles = (names diff names.distinct).distinct
     assert(
       duplicateFiles.isEmpty,
@@ -246,7 +246,7 @@ final class Lib(logger: Logger) extends Stage1Lib(logger) with Scaffold{
     val statusCode =
       new ProcessBuilder( "gpg", "--batch", "--yes", "-a", "-b", "-s", "--passphrase", passphrase, file.toString )
         .inheritIO.start.waitFor
-    
+
     if( 0 != statusCode ) throw new Exception("gpg exited with status code " ++ statusCode.toString)
 
     file ++ ".asc"
@@ -342,7 +342,7 @@ final class Lib(logger: Logger) extends Stage1Lib(logger) with Scaffold{
           name++".md5" -> md5(content).toArray.map(_.toByte),
           name++".sha1" -> sha1(content).toArray.map(_.toByte)
         )
-      }  
+      }
       val all = (files ++ checksums)
       uploadAll(url, all)
     }


### PR DESCRIPTION
I believe this closes #76 and #80 in one go. This should also fix the issues with our CI not detecting that our tests have failed because those error codes should be properly bubbling too. There are also a handful of whitespace fixes because my editor does that automatically.

I also did a bit of cleanup of `zinc(...)`