### PR TITLE
Improved how to express dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,12 @@ class Build(context: cbt.Context) extends PackageBuild(context){
   override def groupId = "org.cvogt"
   override def artifactId = "play-json-extensions"
   override def dependencies = super.dependencies ++ Vector(
-    "com.typesafe.play" %% "play-json" % "2.4.4"
+    // encouraged way to declare dependencies
+    ScalaDependency("com.typesafe.play", "play-json", "2.4.4"),
+    JavaDependency("joda-time", "joda-time", "2.9.2")
+    // also supported for SBT syntax compatibility:
+    // "com.typesafe.play" %% "play-json" % "2.4.4"
+    // "joda-time" % "joda-time % "2.9.2"
   )
   override def compile = {
     println("Compiling...")

--- a/coursier/Coursier.scala
+++ b/coursier/Coursier.scala
@@ -1,7 +1,7 @@
 /*
 package cbt
 object Coursier{
-  implicit class CoursierDependencyResolution(d: MavenDependency){
+  implicit class CoursierDependencyResolution(d: JavaDependency){
     import d._
     def resolveCoursier = {
       import coursier._
@@ -12,7 +12,7 @@ object Coursier{
 
       val start = Resolution(
         Set(
-          MavenDependency(
+          JavaDependency(
             Module(groupId, artifactId), version
           )
         )
@@ -23,7 +23,7 @@ object Coursier{
 
       val resolution = start.process.run(fetch).run
 
-      val errors: Seq[(MavenDependency, Seq[String])] = resolution.errors
+      val errors: Seq[(JavaDependency, Seq[String])] = resolution.errors
 
       if(errors.nonEmpty) throw new Exception(errors.toString)
 
@@ -40,7 +40,7 @@ object Coursier{
         case Right(file) => file
       })
 
-      resolution.dependencies.map( d => cbt.MavenDependency(d.module.organization,d.module.name, d.version)).to[collection.immutable.Seq]
+      resolution.dependencies.map( d => cbt.JavaDependency(d.module.organization,d.module.name, d.version)).to[collection.immutable.Seq]
     }
   }
 }

--- a/stage1/constants.scala
+++ b/stage1/constants.scala
@@ -1,4 +1,5 @@
 package cbt
 object constants{
-  def scalaVersion = Option(System.getenv("SCALA_VERSION")).get
+  val scalaVersion = Option(System.getenv("SCALA_VERSION")).get
+  val scalaMajorVersion = scalaVersion.split("\\.").take(2).mkString(".")
 }

--- a/stage2/AdminTasks.scala
+++ b/stage2/AdminTasks.scala
@@ -7,7 +7,7 @@ class AdminTasks(lib: Lib, args: Array[String]){
       args(1).split(",").toVector.map{
         d =>
           val v = d.split(":")
-          new MavenDependency(v(0),v(1),v(2))(lib.logger).classpath
+          new JavaDependency(v(0),v(1),v(2))(lib.logger).classpath
       }
     )
   }
@@ -15,7 +15,7 @@ class AdminTasks(lib: Lib, args: Array[String]){
   def ammonite = {
     val version = args.lift(1).getOrElse(constants.scalaVersion)
     val scalac = new ScalaCompilerDependency( version )
-    val d = MavenDependency(
+    val d = JavaDependency(
       "com.lihaoyi","ammonite-repl_2.11.7",args.lift(1).getOrElse("0.5.6")
     )
     // FIXME: this does not work quite yet, throws NoSuchFileException: /ammonite/repl/frontend/ReplBridge$.class

--- a/stage2/BuildDependency.scala
+++ b/stage2/BuildDependency.scala
@@ -28,7 +28,7 @@ case class BuildDependency(context: Context) extends TriggerLoop{
   final val updated = build.updated
 }
 /*
-case class DependencyOr(first: BuildDependency, second: MavenDependency) extends ProjectProxy with BuildDependencyBase{
+case class DependencyOr(first: BuildDependency, second: JavaDependency) extends ProjectProxy with BuildDependencyBase{
   val isFirst = new File(first.context.cwd).exists
   def triggerLoopFiles = if(isFirst) first.triggerLoopFiles else Seq()
   protected val delegate = if(isFirst) first else second

--- a/stage2/PackageBuild.scala
+++ b/stage2/PackageBuild.scala
@@ -1,6 +1,5 @@
 package cbt
 import java.io.File
-import java.net.URL
 import scala.collection.immutable.Seq
 abstract class PackageBuild(context: Context) extends BasicBuild(context) with ArtifactInfo{
   def `package`: Seq[File] = lib.concurrently( enableConcurrency )(

--- a/test/simple/build/build.scala
+++ b/test/simple/build/build.scala
@@ -1,0 +1,9 @@
+import cbt._
+import scala.collection.immutable.Seq
+import java.io.File
+class Build(context: cbt.Context) extends BasicBuild(context){
+  override def dependencies = Seq(
+    ScalaDependency("com.typesafe.play", "play-json", "2.4.4"),
+    JavaDependency("joda-time", "joda-time", "2.9.2")
+  ) ++ super.dependencies 
+}

--- a/test/test.scala
+++ b/test/test.scala
@@ -67,13 +67,15 @@ object Main{
     compile("nothing")
     usage("multi-build")
     compile("multi-build")
+    usage("simple")
+    compile("simple")
     
     {
       val noContext = Context(cbtHome ++ "/test/nothing", Seq(), logger)
       val b = new Build(noContext){
         override def dependencies = Seq(
-          MavenDependency("net.incongru.watchservice","barbary-watchservice","1.0")(logger),
-          MavenDependency("net.incongru.watchservice","barbary-watchservice","1.0")(logger)
+          JavaDependency("net.incongru.watchservice","barbary-watchservice","1.0"),
+          JavaDependency("net.incongru.watchservice","barbary-watchservice","1.0")
         )
       }
       val cp = b.classpath


### PR DESCRIPTION
Add
- Constructor syntax for cross-scala-version dependencies (as rightfully requested on reddit) and encouraged over SBT's still supported operator syntax
- Add support for classifiers other than "sources"