### PR TITLE
cross building and automatic snaphot ids

### DIFF
--- a/stage1/Stage1Lib.scala
+++ b/stage1/Stage1Lib.scala
@@ -31,7 +31,16 @@ object CatchTrappedExitCode{
   }
 }
 
-case class Context( projectDirectory: File, cwd: File, args: Seq[String], logger: Logger, cbtHasChanged: Boolean, classLoaderCache: ClassLoaderCache )
+case class Context(
+  projectDirectory: File,
+  cwd: File,
+  args: Seq[String],
+  logger: Logger,
+  cbtHasChanged: Boolean,
+  classLoaderCache: ClassLoaderCache,
+  version: Option[String] = None,
+  scalaVersion: Option[String] = None
+)
 
 class BaseLib{
   def realpath(name: File) = new File(Paths.get(name.getAbsolutePath).normalize.toString)

--- a/stage2/BasicBuild.scala
+++ b/stage2/BasicBuild.scala
@@ -29,8 +29,11 @@ class Build(val context: Context) extends Dependency with TriggerLoop with SbtDe
 
   // ========== meta data ==========
 
-  def scalaVersion: String = constants.scalaVersion
+  def defaultScalaVersion: String = constants.scalaVersion
+  final def scalaVersion = context.scalaVersion getOrElse defaultScalaVersion
   final def scalaMajorVersion: String = lib.scalaMajorVersion(scalaVersion)
+  def crossScalaVersions: Seq[String] = Seq(scalaVersion, "2.10.6")
+  def copy(context: Context) = lib.copy(this.getClass, context).asInstanceOf[Build]
   def zincVersion = "0.3.9"
 
   def dependencies: Seq[Dependency] = Seq(

--- a/stage2/Lib.scala
+++ b/stage2/Lib.scala
@@ -24,6 +24,11 @@ final class Lib(logger: Logger) extends Stage1Lib(logger) with Scaffold{
   val buildClassName = "Build"
   val buildBuildClassName = "BuildBuild"
 
+  def copy(cls: Class[_], context: Context) = 
+    cls
+    .getConstructor(classOf[Context])
+    .newInstance(context)
+
   /** Loads Build for given Context */
   def loadDynamic(context: Context, default: Context => Build = new Build(_)): Build = {
     context.logger.composition( context.logger.showInvocation("Build.loadDynamic",context) )
@@ -53,16 +58,16 @@ final class Lib(logger: Logger) extends Stage1Lib(logger) with Scaffold{
     }
   }
 
-  def srcJar(sourceFiles: Seq[File], artifactId: String, version: String, jarTarget: File): Option[File] = {
+  def srcJar(sourceFiles: Seq[File], artifactId: String, scalaMajorVersion: String, version: String, jarTarget: File): Option[File] = {
     lib.jarFile(
-      jarTarget ++ ("/"++artifactId++"-"++version++"-sources.jar"),
+      jarTarget ++ ("/"++artifactId++"_"++scalaMajorVersion++"-"++version++"-sources.jar"),
       sourceFiles
     )
   }
 
-  def jar(artifactId: String, version: String, compileTarget: File, jarTarget: File): Option[File] = {
+  def jar(artifactId: String, scalaMajorVersion: String, version: String, compileTarget: File, jarTarget: File): Option[File] = {
     lib.jarFile(
-      jarTarget ++ ("/"++artifactId++"-"++version++".jar"),
+      jarTarget ++ ("/"++artifactId++"_"++scalaMajorVersion++"-"++version++".jar"),
       Seq(compileTarget)
     )
   }
@@ -74,6 +79,7 @@ final class Lib(logger: Logger) extends Stage1Lib(logger) with Scaffold{
     apiTarget: File,
     jarTarget: File,
     artifactId: String,
+    scalaMajorVersion: String,
     version: String,
     compileArgs: Seq[String],
     classLoaderCache: ClassLoaderCache
@@ -96,7 +102,7 @@ final class Lib(logger: Logger) extends Stage1Lib(logger) with Scaffold{
         )
       }
       lib.jarFile(
-        jarTarget ++ ("/"++artifactId++"-"++version++"-javadoc.jar"),
+        jarTarget ++ ("/"++artifactId++"_"++scalaMajorVersion++"-"++version++"-javadoc.jar"),
         Vector(apiTarget)
       )
     }

--- a/stage2/PackageBuild.scala
+++ b/stage2/PackageBuild.scala
@@ -2,23 +2,25 @@ package cbt
 import java.io.File
 import scala.collection.immutable.Seq
 abstract class PackageBuild(context: Context) extends BasicBuild(context) with ArtifactInfo{
+  def defaultVersion: String
+  final def version = context.version getOrElse defaultVersion
   def `package`: Seq[File] = lib.concurrently( enableConcurrency )(
     Seq(() => jar, () => docJar, () => srcJar)
   )( _() ).flatten
 
   private object cacheJarBasicBuild extends Cache[Option[File]]
   def jar: Option[File] = cacheJarBasicBuild{
-    compile.flatMap( lib.jar( artifactId, version, _, jarTarget ) )
+    compile.flatMap( lib.jar( artifactId, scalaMajorVersion, version, _, jarTarget ) )
   }
 
   private object cacheSrcJarBasicBuild extends Cache[Option[File]]
   def srcJar: Option[File] = cacheSrcJarBasicBuild{
-    lib.srcJar( sourceFiles, artifactId, version, scalaTarget )
+    lib.srcJar( sourceFiles, artifactId, scalaMajorVersion, version, scalaTarget )
   }
 
   private object cacheDocBasicBuild extends Cache[Option[File]]
   def docJar: Option[File] = cacheDocBasicBuild{
-    lib.docJar( scalaVersion, sourceFiles, dependencyClasspath, apiTarget, jarTarget, artifactId, version, scalacOptions, context.classLoaderCache )
+    lib.docJar( scalaVersion, sourceFiles, dependencyClasspath, apiTarget, jarTarget, artifactId, scalaMajorVersion, version, scalacOptions, context.classLoaderCache )
   }
 
   override def jars = jar.toVector ++ dependencyJars

--- a/stage2/PublishBuild.scala
+++ b/stage2/PublishBuild.scala
@@ -36,6 +36,11 @@ abstract class PublishBuild(context: Context) extends PackageBuild(context){
   final protected def releaseFolder = s"/${groupId.replace(".","/")}/$artifactId/$version/"
   def snapshotUrl = new URL("https://oss.sonatype.org/content/repositories/snapshots")
   def releaseUrl = new URL("https://oss.sonatype.org/service/local/staging/deploy/maven2")
-  def publishSnapshot: Unit = lib.publishSnapshot(sourceFiles, pom +: `package`, snapshotUrl ++ releaseFolder )
+  override def copy(context: Context) = super.copy(context).asInstanceOf[PublishBuild]
+  def publishSnapshot: Unit = {
+    val snapshotBuild = copy( context.copy(version = Some(version+"-SNAPSHOT")) )
+    val files = snapshotBuild.pom +: snapshotBuild.`package`
+    lib.publishSnapshot(sourceFiles, files, snapshotUrl ++ releaseFolder )
+  }
   def publishSigned: Unit = lib.publishSigned(sourceFiles, pom +: `package`, releaseUrl ++ releaseFolder )
 }

--- a/stage2/mixins.scala
+++ b/stage2/mixins.scala
@@ -5,7 +5,7 @@ import java.io._
 trait Test extends Build{
   lazy val testedBuild = BuildDependency( projectDirectory.parent )
   override def dependencies = Seq( testedBuild ) ++ super.dependencies
-  override def scalaVersion = testedBuild.build.scalaVersion
+  override def defaultScalaVersion = testedBuild.build.scalaVersion
 }
 trait Sbt extends Build{
   override def sources = Seq( projectDirectory ++ "/src/main/scala" )

--- a/test/simple/build/build.scala
+++ b/test/simple/build/build.scala
@@ -7,7 +7,7 @@ class Build(context: cbt.Context) extends BasicBuild(context){
     super.dependencies
     ++
     Seq(
-      GitDependency("https://github.com/xdotai/diff.git", "8b501902999fe76d49e04937c4bd6d0b9e07b4a6"),
+      GitDependency("https://github.com/xdotai/diff.git", "666bbbf4dbff6fadc81c011ade7b83e91d3f9256"),
       MavenRepository.central.resolve(
         ScalaDependency("com.typesafe.play", "play-json", "2.4.4"),
         MavenDependency("joda-time", "joda-time", "2.9.2"),


### PR DESCRIPTION
Adds support for cross building for multiple scala versions
And for automatically appending -SNAPSHOT to the id, when publishing a snapshot.