### PR TITLE
Reduce boiler plate from build files by aliasing File, URL, Seq in BasicBuild

### DIFF
--- a/build/build.scala
+++ b/build/build.scala
@@ -1,8 +1,4 @@
 import cbt._
-import java.net.URL
-import java.io.File
-import scala.collection.immutable.Seq
-
 class Build(context: Context) extends BasicBuild(context){
   // FIXME: somehow consolidate this with cbt's own boot-strapping from source.
   override def dependencies = {

--- a/examples/build-scalatest/build/build.scala
+++ b/examples/build-scalatest/build/build.scala
@@ -1,8 +1,4 @@
 import cbt._
-import java.net.URL
-import java.io.File
-import scala.collection.immutable.Seq
-
 class Build( context: Context ) extends BasicBuild( context ) with SbtLayout {
 
   override def dependencies = (

--- a/examples/build-scalatest/build/build/build.scala
+++ b/examples/build-scalatest/build/build/build.scala
@@ -1,8 +1,4 @@
 import cbt._
-import java.net.URL
-import java.io.File
-import scala.collection.immutable.Seq
-
 class Build( context: Context ) extends BuildBuild( context ){
 
   override def dependencies = (

--- a/plugins/scalatest/ScalaTest.scala
+++ b/plugins/scalatest/ScalaTest.scala
@@ -1,7 +1,4 @@
 import cbt._
-import java.net.URL
-import java.io.File
-import scala.collection.immutable.Seq
 import org.scalatest._
 import org.scalatest
 

--- a/plugins/scalatest/build/build.scala
+++ b/plugins/scalatest/build/build.scala
@@ -1,7 +1,4 @@
 import cbt._
-import java.net.URL
-import java.io.File
-import scala.collection.immutable.Seq
 
 class Build(context: Context) extends BasicBuild(context){
   override def dependencies =

--- a/stage2/BasicBuild.scala
+++ b/stage2/BasicBuild.scala
@@ -22,6 +22,11 @@ trait Recommended extends BasicBuild{
   )
 }
 class BasicBuild(val context: Context) extends DependencyImplementation with BuildInterface with TriggerLoop with SbtDependencyDsl{
+  type URL = java.net.URL
+  type File = java.io.File
+  type Seq[A] = scala.collection.immutable.Seq[A]
+  val Seq = scala.collection.immutable.Seq
+
   // library available to builds
   implicit protected final val logger: Logger = context.logger
   implicit protected final val classLoaderCache: ClassLoaderCache = context.classLoaderCache

--- a/stage2/BuildBuild.scala
+++ b/stage2/BuildBuild.scala
@@ -1,7 +1,5 @@
 package cbt
-import java.io.File
 import java.nio.file._
-import scala.collection.immutable.Seq
 
 class BuildBuild(context: Context) extends BasicBuild(context){
   override def dependencies =

--- a/stage2/PackageBuild.scala
+++ b/stage2/PackageBuild.scala
@@ -1,6 +1,4 @@
 package cbt
-import java.io.File
-import scala.collection.immutable.Seq
 abstract class PackageBuild(context: Context) extends BasicBuild(context) with ArtifactInfo{
   def defaultVersion: String
   final def version = context.version getOrElse defaultVersion

--- a/stage2/PublishBuild.scala
+++ b/stage2/PublishBuild.scala
@@ -1,8 +1,5 @@
 package cbt
-import java.io.File
-import java.net.URL
 import java.nio.file.Files.readAllBytes
-import scala.collection.immutable.Seq
 
 abstract class PublishBuild(context: Context) extends PackageBuild(context){
   def name = artifactId

--- a/stage2/Scaffold.scala
+++ b/stage2/Scaffold.scala
@@ -29,10 +29,6 @@ trait Scaffold{
     projectDirectory: File
   ): Unit = { 
     createFile(projectDirectory, "build/build.scala", s"""import cbt._
-import java.net.URL
-import java.io.File
-import scala.collection.immutable.Seq
-
 class Build( context: Context ) extends BasicBuild( context ){
   /*
   override def dependencies = (
@@ -62,10 +58,6 @@ class Build( context: Context ) extends BasicBuild( context ){
     projectDirectory: File
   ): Unit = { 
     createFile(projectDirectory, "build/build/build.scala", s"""import cbt._
-import java.net.URL
-import java.io.File
-import scala.collection.immutable.Seq
-
 class Build( context: Context ) extends BuildBuild( context ){
 /*
   override def dependencies = (
@@ -94,10 +86,6 @@ class Build( context: Context ) extends BuildBuild( context ){
 /*,
 
       "build/build/build.scala" -> s"""import cbt._
-import java.net.URL
-import java.io.File
-import scala.collection.immutable.Seq
-
 class Build(context: Context) extends BuildBuild(context){
   override def dependencies = super.dependencies ++ Seq(
     BuildDependency( projectDirectory.parent ++ "/build-shared")
@@ -114,10 +102,6 @@ class Build(context: Context) extends BuildBuild(context){
 """,
 
       "test/build/build.scala" -> s"""import cbt._
-import java.net.URL
-import java.io.File
-import scala.collection.immutable.Seq
-
 class Build(context: cbt.Context) extends BasicBuild(context) with BuildShared/* with cbt.mixins.ScalaTest*/{
   // def scalaTestVersion = "2.2.6"
   
@@ -128,10 +112,6 @@ class Build(context: cbt.Context) extends BasicBuild(context) with BuildShared/*
 """,
 
       "test/build/build/build.scala" -> s"""import cbt._
-import java.net.URL
-import java.io.File
-import scala.collection.immutable.Seq
-
 class Build(context: Context) extends BuildBuild(context){
   override def scalaVersion: String = "2.11.8"
   
@@ -143,10 +123,6 @@ class Build(context: Context) extends BuildBuild(context){
 """,
 
       "build-shared/build/build.scala" -> s"""import cbt._
-import java.net.URL
-import java.io.File
-import scala.collection.immutable.Seq
-
 class Build(context: Context) extends BasicBuild(context){
   override def scalaVersion: String = "$scalaVersion"
 
@@ -158,10 +134,6 @@ class Build(context: Context) extends BasicBuild(context){
 """,
 
       "build-shared/BuildShared.scala" -> s"""import cbt._
-import java.net.URL
-import java.io.File
-import scala.collection.immutable.Seq
-
 trait BuildShared extends BasicBuild{
   override def scalaVersion: String = "$scalaVersion"
   override def enableConcurrency = false // enable for speed, disable for debugging

--- a/test/build/build.scala
+++ b/test/build/build.scala
@@ -1,6 +1,4 @@
 import cbt._
-import java.io.File
-import scala.collection.immutable.Seq
 class Build(context: cbt.Context) extends BasicBuild(context){
   override def dependencies = Seq( context.cbtDependency ) ++ super.dependencies 
 }

--- a/test/multi-build/build/build.scala
+++ b/test/multi-build/build/build.scala
@@ -1,6 +1,4 @@
 import cbt._
-import scala.collection.immutable.Seq
-import java.io.File
 class Build(context: Context) extends BasicBuild(context){
   override def dependencies = Seq(
     BuildDependency(projectDirectory++"/sub1"),

--- a/test/simple-fixed/build/build.scala
+++ b/test/simple-fixed/build/build.scala
@@ -1,7 +1,4 @@
 import cbt._
-import scala.collection.immutable.Seq
-import java.io.File
-
 // cbt:https://github.com/cvogt/cbt.git#ca412e26d70a6615153136019b7966acb9939446
 class Build(context: cbt.Context) extends BasicBuild(context){
   override def dependencies = (

--- a/test/simple/build/build.scala
+++ b/test/simple/build/build.scala
@@ -1,7 +1,4 @@
 import cbt._
-import scala.collection.immutable.Seq
-import java.io.File
-
 class Build(context: cbt.Context) extends BasicBuild(context){
   override def dependencies = (
     super.dependencies


### PR DESCRIPTION
Discussed here on twitter https://gitter.im/cvogt/cbt?at=5752127e1097267921302d84

This might actually be a bad idea. While it does reduce the boiler plate of build files, it adds magic (if you count injection via inheritance scope as magical, which is probably a good idea).

Somewhat related to #137.