### PR TITLE
Interactive mode implemented with readline. This allows not having to…

### DIFF
--- a/cbt
+++ b/cbt
@@ -225,10 +225,39 @@ stage1 () {
 }
 
 while true; do
-	stage1 $*
+	interactive=false
+
+	if [ "$1" = "interactive" ]; then
+		interactive=true
+	else
+		stage1 $*
+	fi
+
+	while [ "$interactive" = true ]; do
+		while IFS="" read -r -e -d $'\n' -p 'cbt> ' options; do
+		  history -s "$options"
+			if [ "$options" = "quit" ]; then
+				interactive=false
+				break
+			else
+        curr_command="$(echo $options | { read first rest ; echo $first ; })"
+        which $curr_command 2>&1 > /dev/null
+        option_available=$?
+        if [ ! $option_available -eq 0 ]; then
+          cbt "$options"
+        else
+          eval $options
+        fi
+				
+			fi
+		done
+	done
 	if [ ! "$1" = "loop" ]; then
 		break
 	fi
+  if [ "$1" = "quit" ]; then
+    break
+  fi
 	echo "======= Restarting CBT =======" 1>&2
 done
 


### PR DESCRIPTION
… tpe "cbt " all the time. It's not as powerful as your native shell, but at least has a command history. When you type a command into cbt's shell, it tries to run system commands first and only if none was found tries to run a cbt task for the provided name. This is an experimental design trying to save people from some constant typing pain. (implemented by @mchav, commit message by @cvogt)