### PR TITLE
Allow empty credentials for publishing.

### DIFF
--- a/stage2/Publish.scala
+++ b/stage2/Publish.scala
@@ -41,9 +41,9 @@ trait Publish extends PackageJars{
   def publishUrl = if(version.endsWith("-SNAPSHOT")) snapshotUrl else releaseUrl
   override def copy(context: Context) = super.copy(context).asInstanceOf[Publish]
 
-  protected def sonatypeCredentials = {
+  protected def sonatypeCredentials: Option[String] = {
     // FIXME: this should probably not use cbtHome, but some reference to the system's host cbt
-    new String(readAllBytes((context.cbtRootHome ++ "/sonatype.login").toPath)).trim
+    Some(new String(readAllBytes((context.cbtRootHome ++ "/sonatype.login").toPath)).trim)
   }
 
   def publishSnapshot: Unit = {


### PR DESCRIPTION
This enables to publish into a repository where no credentials are
required but and empty/wrong HTTP Auth header throws an HTTP 401
(not authorized) error