### PR TITLE
try to fix circleci

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -12,5 +12,6 @@ dependencies:
 
 test:
   override:
+    - rm ~/.gitconfig # avoid url replacement breaking jgit
     - ./cbt direct test
     - ./cbt test


### PR DESCRIPTION
for some reason the circle machines now have a .gitconfig that breaks jgit
it replaces https github urls with ssh github urls in a way jgit does not like