### PR TITLE
Manifest used java.runtime.version for CreatedBy, which gave away inf…

### DIFF
--- a/stage2/Lib.scala
+++ b/stage2/Lib.scala
@@ -276,9 +276,8 @@ final class Lib(logger: Logger) extends Stage1Lib(logger) with Scaffold{
       jarFile.getParentFile.mkdirs
       logger.lib("Start packaging "++jarFile.string)
       val manifest = new Manifest()
-      manifest.getMainAttributes.put(Attributes.Name.MANIFEST_VERSION, "1.0")
-      manifest.getMainAttributes.putValue("Created-By",
-        Option(System.getProperty("java.runtime.version")) getOrElse "1.7.0_06 (Oracle Corporation)")
+      manifest.getMainAttributes.put( Attributes.Name.MANIFEST_VERSION, "1.0" )
+      manifest.getMainAttributes.putValue( "Created-By", "Chris' Build Tool" )
       mainClass foreach { className =>
         manifest.getMainAttributes.put(Attributes.Name.MAIN_CLASS, className)
       }


### PR DESCRIPTION
…o on the java update version, which may be a security risk for the releaser. So now we just say CBT created in instead similar to what other tools are doing.