### PR TITLE
upgrade scalafmt 0.3.1 -> 0.4.2; load scalafmt config from config file

### DIFF
--- a/examples/scalafmt-example/.scalafmt.conf
+++ b/examples/scalafmt-example/.scalafmt.conf
@@ -1,0 +1,11 @@
+style: defaultWithAlign
+danglingParentheses: true
+
+spaces {
+  inImportCurlyBraces: true
+}
+
+rewriteTokens {
+  "->": "→"
+  "=>": "⇒"
+}

--- a/examples/scalafmt-example/build/build.scala
+++ b/examples/scalafmt-example/build/build.scala
@@ -1,13 +1,10 @@
 import cbt._
-import org.scalafmt.ScalafmtStyle
 
 class Build(val context: Context) extends BaseBuild with Scalafmt {
   override def compile = {
     scalafmt
     super.compile
   }
-
-  override def scalafmtConfig: ScalafmtStyle = ScalafmtStyle.defaultWithAlign
 
   def breakFormatting = {
     import java.nio.file._
@@ -17,7 +14,11 @@ class Build(val context: Context) extends BaseBuild with Scalafmt {
     sourceFiles foreach { file =>
       val path = file.toPath
       val fileLines = Files.readAllLines(path, utf8).asScala
-      val brokenLines = fileLines map (_.dropWhile(_ == ' '))
+      val brokenLines = fileLines map (l =>
+        l.dropWhile(_ == ' ')
+          .replaceAll("⇒", "=>")
+          .replaceAll("→", "->")
+        )
       Files.write(path, brokenLines.asJava, utf8)
     }
     System.err.println("Done breaking formatting")

--- a/examples/scalafmt-example/src/Main.scala
+++ b/examples/scalafmt-example/src/Main.scala
@@ -1,16 +1,16 @@
-import scala.concurrent.{Await, Future}
+import scala.concurrent.{ Await, Future }
 import scala.concurrent.duration._
 
 object Main extends App {
   println("fooo")
   val futureRes = Await.result(Future.successful(1), 5.seconds)
   List(1, 2, 4, 5, 6) match {
-    case h :: _ => println("not empty list")
-    case Nil    => println("empty list")
+    case h :: _ ⇒ println("not empty list")
+    case Nil    ⇒ println("empty list")
   }
 
-  List(1 -> 2, 2 -> 3, 3 -> 4) match {
-    case (1, 2) :: _   => 90 -> 1
-    case (22, 44) :: _ => 1  -> 150
+  List(1 → 2, 2 → 3, 3 → 4) match {
+    case (1, 2) :: _   ⇒ 90 → 1
+    case (22, 44) :: _ ⇒ 1  → 150
   }
 }

--- a/plugins/scalafmt/build/build.scala
+++ b/plugins/scalafmt/build/build.scala
@@ -1,9 +1,12 @@
 import cbt._
 
 class Build(val context: Context) extends Plugin {
+  private val ScalafmtVersion = "0.4.2"
+
   override def dependencies =
     super.dependencies ++
     Resolver( mavenCentral ).bind(
-      ScalaDependency("com.geirsson", "scalafmt", "0.3.1")
+      ScalaDependency("com.geirsson", "scalafmt", ScalafmtVersion),
+      ScalaDependency("com.geirsson", "scalafmt-cli", ScalafmtVersion)
     )
 }


### PR DESCRIPTION
Did some improvements to scalafmt plugin. Now, it uses config from .scalafmt.conf by default, as it does sbt-plugin and IDEA plugin.