### PR TITLE
Attempt to improve jvm startup time

### DIFF
--- a/cbt
+++ b/cbt
@@ -194,7 +194,8 @@ stage1 () {
 	then
 		log "Running JVM directly" $*
 		# -Xrunjdwp:transport=dt_socket,server=y,suspend=y,address=localhost:5005
-		java $JAVA_OPTS -Xmx6072m -Xss10M -cp $NAILGUN$TARGET cbt.NailgunLauncher $(time_taken) "$CWD" $*
+		# JVM options to improve startup time. See https://github.com/cvogt/cbt/pull/262
+		java $JAVA_OPTS -Xmx6072m -Xss10M -XX:+TieredCompilation -XX:TieredStopAtLevel=1 -Xverify:none -cp $NAILGUN$TARGET cbt.NailgunLauncher $(time_taken) "$CWD" $*
 	else
 		log "Running via background process (nailgun)" $*
 		for i in 0 1 2 3 4 5 6 7 8 9; do


### PR DESCRIPTION
Tried to improve plain JVM(no nailgun) startup time by applying common advices.

Info taken from here,:
https://jkutner.github.io/2015/12/01/java-boot-time.html#other-options-with-side-effects
https://github.com/jruby/jruby/wiki/Improving-startup-time#use-the-client-mode-of-the-jvm

Results on my laptop: 
java -version:
```
➜  cbt-args java -version
java version "1.8.0_72"
Java(TM) SE Runtime Environment (build 1.8.0_72-b15)
Java HotSpot(TM) 64-Bit Server VM (build 25.72-b15, mixed mode)
```

before:
```
➜  cbt-args time cbt foo
cbt foo  1.59s user 0.22s system 163% cpu 1.106 total
➜  cbt-args time cbt foo
cbt foo  1.58s user 0.21s system 176% cpu 1.018 total
➜  cbt-args time cbt foo
cbt foo  1.63s user 0.20s system 173% cpu 1.056 total
➜  cbt-args time cbt foo
cbt foo  1.62s user 0.22s system 171% cpu 1.076 total
➜  cbt-args time cbt foo
cbt foo  1.65s user 0.22s system 175% cpu 1.061 total
➜  cbt-args time cbt foo
cbt foo  1.70s user 0.21s system 174% cpu 1.092 total
```

after:
```
➜  cbt-args time cbt foo
cbt foo  0.86s user 0.19s system 127% cpu 0.832 total
➜  cbt-args time cbt foo
cbt foo  0.86s user 0.18s system 128% cpu 0.811 total
➜  cbt-args time cbt foo
cbt foo  0.87s user 0.18s system 128% cpu 0.817 total
➜  cbt-args time cbt foo
cbt foo  0.93s user 0.19s system 126% cpu 0.884 total
```