### PR TITLE
fix file watching for real

### DIFF
--- a/DEVELOPER_GUIDE.txt
+++ b/DEVELOPER_GUIDE.txt
@@ -29,7 +29,7 @@ compatibility/      Java interfaces that all CBT versions are source compatible 
 nailgun_launcher/   Self-contained helper that allows using Nailgun with minimal permanent classpath. (Is this actually needed?)
 realpath/           Self-contained realpath source code to correctly figure our CBTs home directory. (Open for replacement ideas.)
 stage1/             CBT's code that only relies only on Scala/Java built-ins. Contains a Maven resolver to download libs for stage2.
-stage2/             CBT's code that requires additional libs, e.g. barbary watchservice.
+stage2/             CBT's code that requires additional libs, e.g. jgit
 test/               Unit tests that can serve as example builds
 sonatype.login      Sonatype credentials for deployment. Not in git obviously.
 

--- a/README.md
+++ b/README.md
@@ -203,7 +203,8 @@ As you can see it prints `asdf`. Adding tasks is that easy.
 
 ### Triggering tasks on file-changes
 
-When you call a task, you can prefix it with `loop`.
+When you call a task, you can prefix it with `loop`. You need to
+have fswatch install (e.g. via `brew install fswatch`).
 CBT then watches the source files, the build files and even CBT's own
 source code and re-runs the task when anything changes. If necessary,
 this forces CBT to re-build itself, the project's dependencies and the project itself.
@@ -219,6 +220,11 @@ CBT is fast. It may already be done re-compiling and re-running before
 you managed to change windows back from your editor to the shell.
 
 Try changing the build file and see how CBT reacts to it as well.
+
+To also clear the screen on each run use:
+```
+$ cbt loop clear run
+```
 
 ### Adding tests
 

--- a/build/build.scala
+++ b/build/build.scala
@@ -10,7 +10,6 @@ class Build(val context: Context) extends Shared with PublishLocal{
   // FIXME: somehow consolidate this with cbt's own boot-strapping from source.
   override def dependencies = {
     super.dependencies ++ Resolver(mavenCentral).bind(
-      MavenDependency("net.incongru.watchservice","barbary-watchservice","1.0"),
       MavenDependency("org.eclipse.jgit", "org.eclipse.jgit", "4.2.0.201601211800-r"),
       ScalaDependency("org.scala-lang.modules","scala-xml","1.0.5")
     )

--- a/cbt
+++ b/cbt
@@ -170,6 +170,17 @@ if [  "$1" = "direct" ]; then
 	use_nailgun=1
 	shift
 fi
+loop=1
+if [ "$1" == "loop" ]; then
+	loop=0
+	shift
+fi
+clearScreen=1
+if [ "$1" == "clear" ]; then
+	clearScreen=0
+	shift
+fi
+
 if [ $nailgun_installed -eq 1 ] || [ "$1" = "publishSigned" ]; then
 	use_nailgun=1
 fi
@@ -184,7 +195,8 @@ stage1 () {
 	log "Checking for changes in cbt/nailgun_launcher" "$@"
 	NAILGUN_INDICATOR=$NAILGUN$TARGET../classes.last-success
 	changed=1
-	for file in "$NAILGUN"/*.java; do
+	NAILGUN_SOURCES=("$NAILGUN"*.java)
+	for file in "${NAILGUN_SOURCES[@]}"; do
 		if [ "$file" -nt "$NAILGUN_INDICATOR" ]; then changed=0; fi
 	done
 	exitCode=0
@@ -194,7 +206,8 @@ stage1 () {
 		#rm $NAILGUN$TARGET/cbt/*.class 2>/dev/null # defensive delete of potentially broken class files
 		echo "Compiling cbt/nailgun_launcher" 1>&2
 		COMPILE_TIME=$(date +%YY%mm%dd%HH%MM.%SS|sed "s/[YmdHMS]//g")
-		javac -Xlint:deprecation -Xlint:unchecked -d "$NAILGUN$TARGET" "$NAILGUN"*.java
+		#echo javac -Xlint:deprecation -Xlint:unchecked -d "$NAILGUN$TARGET" "${NAILGUN_SOURCES[@]}"
+		javac -Xlint:deprecation -Xlint:unchecked -d "$NAILGUN$TARGET" "${NAILGUN_SOURCES[@]}"
 		exitCode=$?
 		if [ $exitCode -eq 0 ]; then
 			touch -t "$COMPILE_TIME" "$NAILGUN_INDICATOR"
@@ -214,7 +227,7 @@ stage1 () {
 			log "Running JVM directly" "$@"
 			options=($JAVA_OPTS)
 			# JVM options to improve startup time. See https://github.com/cvogt/cbt/pull/262
-			java "${options[@]}" $DEBUG -Xmx6072m -Xss10M -XX:MaxJavaStackTraceDepth=-1 -XX:+TieredCompilation -XX:TieredStopAtLevel=1 -Xverify:none -cp "$NAILGUN$TARGET" cbt.NailgunLauncher "$(time_taken)" "$CWD" "$@"
+			java "${options[@]}" $DEBUG -Xmx6072m -Xss10M -XX:MaxJavaStackTraceDepth=-1 -XX:+TieredCompilation -XX:TieredStopAtLevel=1 -Xverify:none -cp "$NAILGUN$TARGET" cbt.NailgunLauncher "$(time_taken)" "$CWD" "$loop" "$@"
 			exitCode=$?
 		else
 			log "Running via background process (nailgun)" "$@"
@@ -238,7 +251,7 @@ stage1 () {
 				sleep 0.3
 			done
 			log "Running CBT via Nailgun." "$@"
-			$NG cbt.NailgunLauncher "$(time_taken)" "$CWD" "$@"
+			$NG cbt.NailgunLauncher "$(time_taken)" "$CWD" "$loop" "$@"
 			exitCode=$?
 		fi
 		log "Done running CBT." "$@"
@@ -246,46 +259,39 @@ stage1 () {
 }
 
 
-loop=1
-case "$1" in
-	"loop") loop=0
-esac
-case "$2" in
-	"loop") loop=0
-esac
-
-CBT_SIGNALS_LOOPING=253
 USER_PRESSED_CTRL_C=130
 
 CBT_LOOP_FILE="$CWD/target/.cbt-loop.tmp"
+if [ $loop -eq 0 ]; then
+	which fswatch >/dev/null 2>/dev/null
+	export fswatch_installed=$?
+	if [ ! $fswatch_installed -eq 0 ]; then
+		echo "please install fswatch to use cbt loop, e.g. via brew install fswatch"
+		exit 1
+	fi
+fi
 while true; do
+	if [ $clearScreen -eq 0 ]; then
+		clear
+	fi
+	if [ -f "$CBT_LOOP_FILE" ]; then
+		rm "$CBT_LOOP_FILE"
+	fi
 	stage1 "$@"
 	if [ ! $loop -eq 0 ] || [ $exitCode -eq $USER_PRESSED_CTRL_C ]; then
 		log "not looping, exiting" "$@"
 		break
 	else
-		if [ ! $exitCode -eq $CBT_SIGNALS_LOOPING ]; then
-			log "exitCode $exitCode" "$@"
-			which fswatch >/dev/null 2>/dev/null
-			export fswatch_installed=$?
-			if [ -f "$CBT_LOOP_FILE" ]; then
-				if [ $fswatch_installed -eq 0 ]; then
-					# fswatch allows looping over CBT's sources itself
-					log "fswatch found. looping." "$@"
-					files=($(cat "$CBT_LOOP_FILE"))
-					fswatch --one-event "${files[@]}"
-				else
-					log "fswatch not installed, stopping cbt" "$@"
-					break
-				fi
-			else
-				log "no $CBT_LOOP_FILE file, stopping cbt" "$@"
-				break
-			fi
+		files=
+		if [ -f "$CBT_LOOP_FILE" ]; then
+			files=($(cat "$CBT_LOOP_FILE"))
+			#rm "$CBT_LOOP_FILE"
 		fi
+		echo ""
+		echo "Watching for file changes... (ctrl+c short press for loop, long press for abort)"
+		#echo fswatch --one-event "${NAILGUN_SOURCES[@]}" "${files[@]}"
+		fswatch --one-event "${NAILGUN_SOURCES[@]}" "${files[@]}"
 	fi
-
-	echo "======= Restarting CBT =======" 1>&2
 done
 
 log "Exiting CBT" "$@"

--- a/compatibility/BuildInterface.java
+++ b/compatibility/BuildInterface.java
@@ -6,7 +6,10 @@ public interface BuildInterface extends Dependency{
   public default BuildInterface finalBuild(File current){
     return finalBuild(); // legacy forwarder
   }
-  public abstract File[] triggerLoopFilesArray(); // needed for watching files across composed builds
+  @Deprecated
+  public default File[] triggerLoopFilesArray(){
+    return new File[0];
+  };
 
   // deprecated methods, which clients are still allowed to implement, but not required
   public abstract BuildInterface finalBuild(); // needed to propagage through build builds. Maybe we can get rid of this.

--- a/compatibility/Context.java
+++ b/compatibility/Context.java
@@ -21,6 +21,9 @@ public interface Context{
   public default File workingDirectory(){
     return projectDirectory();
   };
+  public default boolean loop(){
+    return false;
+  };
 
   // methods that exist for longer which every CBT version in use should have by now, no default values needed
   public abstract File cwd(); // REPLACE by something that allows to run cbt on some other directly
@@ -32,9 +35,6 @@ public interface Context{
   public abstract File cbtRootHome(); // REMOVE
   public abstract File compatibilityTarget(); // maybe replace this with search in the classloader for it?
   public abstract BuildInterface parentBuildOrNull();
-  public default File[] triggerLoopFilesArray(){
-    return new File[0]; // REMOVE default value on next compatibility breaking release
-  }
 
   // deprecated methods
   @java.lang.Deprecated

--- a/doc/cbt-developer/version-compatibility.md
+++ b/doc/cbt-developer/version-compatibility.md
@@ -25,6 +25,9 @@ However there are more things that can break compatibility when changed:
 - communication between versions via reflection in particular
   - how the TrapSecurityManager of each CBT version talks to the
     installed TrapSecurityManager via reflection
+- communication via the file system
+  - cache folder location any layout
+  - .cbt-loop.tmp file
 
 ## How to detect accidental breakages?
 

--- a/stage1/ContextImplementation.scala
+++ b/stage1/ContextImplementation.scala
@@ -16,7 +16,7 @@ class ContextImplementation(
   override val cbtRootHome: File,
   override val compatibilityTarget: File,
   override val parentBuildOrNull: BuildInterface,
-  override val triggerLoopFilesArray: Array[File]
+  override val loop: Boolean
 ) extends Context{
   @deprecated("this method is replaced by workingDirectory","")
   def projectDirectory = workingDirectory

--- a/stage1/Stage1Lib.scala
+++ b/stage1/Stage1Lib.scala
@@ -204,7 +204,6 @@ class Stage1Lib( logger: Logger ) extends BaseLib{
     }
   }
 
-
   def compile(
     cbtLastModified: Long,
     sourceFiles: Seq[File],
@@ -475,6 +474,13 @@ ${sourceFiles.sorted.mkString(" \\\n")}
     cache.get( cp, lastModified )
   }
 
+  def addLoopFiles(cwd: File, files: Set[File]) = {
+    lib.write(
+      cwd / "target/.cbt-loop.tmp",
+      files.map(_ + "\n").mkString,
+      StandardOpenOption.APPEND
+    )
+  }
 }
 
 import scala.reflect._

--- a/stage1/cbt.scala
+++ b/stage1/cbt.scala
@@ -84,13 +84,6 @@ object `package`{
       }
     }
   }
-  implicit class BuildInterfaceExtensions(build: BuildInterface){
-    import build._
-    // TODO: if every build has a method triggers a callback if files change
-    // then we wouldn't need this and could provide this method from a
-    // plugin rather than hard-coding trigger files stuff in cbt
-    def triggerLoopFiles: Set[File] = triggerLoopFilesArray.to
-  }
   implicit class ArtifactInfoExtensions(subject: ArtifactInfo){
     import subject._
     def str = s"$groupId:$artifactId:$version"
@@ -121,9 +114,6 @@ object `package`{
     def scalaVersion = Option(scalaVersionOrNull)
     def parentBuild = Option(parentBuildOrNull)
     def cbtLastModified: scala.Long = subject.cbtLastModified
-    def triggerLoopFiles: Set[File] = triggerLoopFilesArray.toSet[File]
-
-    private[cbt] def loopFile = cwd / "target/.cbt-loop.tmp"
 
     def copy(
       workingDirectory: File = workingDirectory,
@@ -133,7 +123,9 @@ object `package`{
       scalaVersion: Option[String] = scalaVersion,
       cbtHome: File = cbtHome,
       parentBuild: Option[BuildInterface] = None,
-      triggerLoopFiles: Set[File] = Set()
+      transientCache: java.util.Map[AnyRef,AnyRef] = transientCache,
+      persistentCache: java.util.Map[AnyRef,AnyRef] = persistentCache,
+      loop: Boolean = loop
     ): Context = new ContextImplementation(
       workingDirectory,
       cwd,
@@ -149,7 +141,7 @@ object `package`{
       cbtRootHome,
       compatibilityTarget,
       parentBuild.getOrElse(null),
-      (triggerLoopFiles ++ triggerLoopFilesArray.toSet[File]).toArray
+      loop
     )
   }
 }

--- a/stage1/resolver.scala
+++ b/stage1/resolver.scala
@@ -29,7 +29,6 @@ trait DependencyImplementation extends Dependency{
   @deprecated("this method was replaced by dependenciesArray","")
   def dependencyClasspathArray = dependencyClasspath.files.toArray
 
-
   /*
   //private type BuildCache = KeyLockedLazyCache[Dependency, Future[ClassPath]]
   def exportClasspathConcurrently: ClassPath = {
@@ -195,7 +194,6 @@ case class CbtDependencies(mavenCache: File, nailgunTarget: File, stage1Target: 
     stage2Target,
     stage1Dependency +:
     MavenResolver(cbtLastModified, mavenCache,mavenCentral).bind(
-      MavenDependency("net.incongru.watchservice","barbary-watchservice","1.0"),
       MavenDependency("org.eclipse.jgit", "org.eclipse.jgit", "4.2.0.201601211800-r")
     )
   )

--- a/stage2/BuildBuild.scala
+++ b/stage2/BuildBuild.scala
@@ -37,8 +37,7 @@ trait BuildBuildWithoutEssentials extends BaseBuild{
 
   protected def managedContext = context.copy(
     workingDirectory = managedBuildDirectory,
-    parentBuild=Some(this),
-    triggerLoopFiles = triggerLoopFiles
+    parentBuild=Some(this)
   )
 
   override def dependencies =

--- a/stage2/BuildDependency.scala
+++ b/stage2/BuildDependency.scala
@@ -10,10 +10,6 @@ sealed abstract class ProjectProxy extends Ha{
   def dependencies = Seq(delegate)
 }
 */
-trait TriggerLoop extends DependencyImplementation{
-  final def triggerLoopFilesArray = triggerLoopFiles.toArray
-  def triggerLoopFiles: Set[File]
-}
 /** You likely want to use the factory method in the BasicBuild class instead of this. */
 object DirectoryDependency{
   def apply(context: Context, pathToNestedBuild: String*): BuildInterface = {
@@ -52,7 +48,6 @@ object DirectoryDependency{
 /*
 case class DependencyOr(first: DirectoryDependency, second: JavaDependency) extends ProjectProxy with DirectoryDependencyBase{
   val isFirst = new File(first.projectDirectory).exists
-  def triggerLoopFiles = if(isFirst) first.triggerLoopFiles else Set()
   protected val delegate = if(isFirst) first else second
 }
 */

--- a/stage2/GitDependency.scala
+++ b/stage2/GitDependency.scala
@@ -26,7 +26,8 @@ object GitDependency{
     val c = taskCache[Dependency]("checkout").memoize{ checkout( url, ref ) }
     DirectoryDependency(
       context.copy(
-        workingDirectory = subDirectory.map(c / _).getOrElse(c)
+        workingDirectory = subDirectory.map(c / _).getOrElse(c),
+        loop = false
       ),
       pathToNestedBuild: _*
     )

--- a/test/test.scala
+++ b/test/test.scala
@@ -144,7 +144,7 @@ object Main{
         cbtHome,
         cbtHome ++ "/compatibilityTarget",
         null,
-        Array()
+        false
       )
 
       val b = new BasicBuild(noContext){


### PR DESCRIPTION
last file watching update didn’t work well enough. This now
- rips out barbary watch service as it seems buggy crashing the jvm
- make cbt exclusively write files to watch to a file
- uses fswatch instead watching all files in that file

fixes #428 
fixes #419 
fixes #418