### PR TITLE
Prototype implementation using Scala reflection to show accessible members when running `cbt`

### DIFF
--- a/stage2/ToolsStage2.scala
+++ b/stage2/ToolsStage2.scala
@@ -2,9 +2,11 @@ package cbt
 import java.io._
 object ToolsStage2 extends Stage2Base{
   def run( _args: Stage2Args ): ExitCode = {
+    import _args.classLoaderCache
+
     val args = _args.args.dropWhile(Seq("tools") contains _)
     val lib = new Lib(_args.logger)
-    val toolsTasks = new ToolsTasks(lib, args, _args.cwd, _args.cache, _args.cbtHome, _args.stage2LastModified)(_args.classLoaderCache)
+    val toolsTasks = new ToolsTasks(lib, args, _args.cwd, _args.cache, _args.cbtHome, _args.stage2LastModified)
     lib.callReflective(toolsTasks, args.lift(0), null)
   }
 }

--- a/stage2/ToolsTasks.scala
+++ b/stage2/ToolsTasks.scala
@@ -2,6 +2,8 @@ package cbt
 import java.net._
 import java.io.{Console=>_,_}
 import java.nio.file._
+
+import scala.reflect.runtime.universe
 class ToolsTasks(
   lib: Lib,
   args: Seq[String],
@@ -9,8 +11,8 @@ class ToolsTasks(
   cache: File,
   cbtHome: File,
   cbtLastModified: Long
-)(implicit classLoaderCache: ClassLoaderCache){
-  def apply: String = "Available methods: " ++ lib.taskNames(getClass).mkString("  ")
+)(implicit classLoaderCache: ClassLoaderCache, typeTag: universe.TypeTag[ToolsTasks]){
+  def apply: String = "Available methods: " ++ lib.taskNames(classOf[ToolsTasks]).mkString("  ")
   override def toString = lib.usage(this.getClass, super.toString)
   private val paths = CbtPaths(cbtHome, cache)
   import paths._


### PR DESCRIPTION
As things currently stand, running `cbt` shows "<none>" for accessible members of Build but a whole bunch from CBT