### PR TITLE
Fix gui summoning browser in headless mode

### DIFF
--- a/tools/gui/src/Main.scala
+++ b/tools/gui/src/Main.scala
@@ -88,7 +88,9 @@ object Main {
       }
     }
     server.start()
-    java.awt.Desktop.getDesktop.browse(new java.net.URI(s"http://localhost:$uiPort/"))
+    if(!java.awt.GraphicsEnvironment.isHeadless()) {
+      java.awt.Desktop.getDesktop.browse(new java.net.URI(s"http://localhost:$uiPort/"))
+    }
 
     println("Press Enter to stop UI server.")
     while (Source.stdin.getLines().next().nonEmpty) {}


### PR DESCRIPTION
I'm using the Windows Subsystem for Linux in my adventures with CBT - and it runs headless, which the GUI tool (up till now) finds surprising and chokes on. This very humble small commit fixes that.