### PR TITLE
Factored out ensimeServerVersion in the Ensime plugin

### DIFF
--- a/stage2/plugins/Ensime.scala
+++ b/stage2/plugins/Ensime.scala
@@ -21,6 +21,8 @@ import scala.util.control.NonFatal
   */
 trait Ensime extends BaseBuild {
 
+  def ensimeServerVersion = "2.0.0-M4"
+
   /** ENSIME server and client configuration. */
   def ensimeConfig: Ensime.EnsimeConfig = Ensime.EnsimeConfig(
     scalaCompilerJars = {
@@ -32,11 +34,11 @@ trait Ensime extends BaseBuild {
     },
     ensimeServerJars = {
       val deps = Dependencies(Resolver(mavenCentral, sonatypeReleases, sonatypeSnapshots).bind(
-        MavenDependency("org.ensime", s"server_$scalaMajorVersion", "2.0.0-SNAPSHOT")
+        MavenDependency("org.ensime", s"server_$scalaMajorVersion", ensimeServerVersion)
       ))
       (deps.dependencies ++ deps.transitiveDependencies).flatMap(_.exportedClasspathArray)
     },
-    ensimeServerVersion = "2.0.0-SNAPSHOT",
+    ensimeServerVersion = ensimeServerVersion,
     rootDir = projectDirectory,
     cacheDir = projectDirectory / ".ensime_cache",
     javaHome = Ensime.jdkHome,


### PR DESCRIPTION
I've started using CBT on my free time (please keep up the good fight) and wanted to get some editor integration. Managed to make it ensime-atom pick the config by applying those changes. 

* This aims at facilitating picking the version for ensime server through overriding
* Bumped the version to 2.0.0-M4 (see https://github.com/ensime/ensime-server/releases) 