### PR TITLE
Windows script fix

### DIFF
--- a/cbt.bat
+++ b/cbt.bat
@@ -18,7 +18,7 @@ REM TODO
 REM   time_taken function
 REM   fswatch
 REM   kill
-REM
+
 
 SETLOCAL EnableExtensions EnableDelayedExpansion
 
@@ -42,7 +42,7 @@ SET NAILGUN_ERR=%NAILGUN_TARGET%nailgun.strerr.log
 MD %NAILGUN_TARGET%
 
 REM - CWD current working directory
-FOR /f "delims=" %%i IN ('cd') DO SET CWD=%%i
+SET "CWD=%cd%"
 
 SET CBT_LOOP_FILE=%CWD%\target\.cbt-loop.tmp
 SET CBT_KILL_FILE=%CWD%\target\.cbt-kill.tmp
@@ -245,12 +245,14 @@ REM first stage of CBT
   for %%f in (%NAILGUN_INDICATOR%) do (
     CALL :date_to_yyyy_mm_dd "%%~tf"
     SET ng_ind_last_mod=!date_formatted!
+    ECHO ng_indicator %%f
   )
   
   for %%f in (%nailgun_sources%) do (
     CALL :date_to_yyyy_mm_dd "%%~tf"
     SET ng_source_last_mod=!date_formatted!
     if "!ng_source_last_mod!" GTR "!ng_ind_last_mod!" ( SET changed=0 )
+    ECHO nailgun_source %%f
   )
   
 	SET exit_code=0

--- a/cbt.bat
+++ b/cbt.bat
@@ -1,196 +1,399 @@
 @ECHO OFF
-REM Launcher bash script that bootstraps CBT from source.
-REM (Some of the code for reporting missing dependencies and waiting for nailgun to come up is a bit weird.)
+REM Launcher batch script that bootstraps CBT from source.
+REM Some of the code for reporting missing dependencies and waiting for nailgun to come up is a bit weird.
 REM This is inentionally kept as small as posible.
-REM Welcome improvements to this file:
+REM Welcomed improvements to this file:
 REM - reduce code size through better ideas
 REM - reduce code size by moving more of this into type-checked Java/Scala code (if possible without performance loss).
 REM - reduction of dependencies
 REM - performance improvements
 
-REM utility function to log message to stderr with stating the time
-setlocal EnableExtensions EnableDelayedExpansion
+REM optional dependencies: 
+REM - ncat      https://nmap.org/
+REM - nailgun   http://martiansoftware.com/nailgun/
 
-where javac > nul 2>&1
+REM 0 is true, 1 is false
 
-if ERRORLEVEL 1 (
-    ECHO You need to install javac! CBT needs it to bootstrap from Java sources into Scala.
-    GOTO :EOF
-)
+SETLOCAL EnableExtensions EnableDelayedExpansion
 
-javac -version > %CBT_HOME%temp.txt 2>&1
-SET /p javac_version_output=<%CBT_HOME%temp.txt
+REM < INIT >
+REM TODO 
+SET time_taken=1.1
 
-FOR /f "tokens=2" %%G IN ("%javac_version_output%") DO SET javac_version=%%G 
+SET SCALA_VER_MAJOR=2
+SET SCALA_VER_MINOR=11
+SET SCALA_VER_BUILD=8
 
-FOR /f "tokens=2 delims=." %%G IN ("%javac_version%") DO SET javac_version_minor=%%G 
+SET TARGET=target\scala-%SCALA_VER_MAJOR%.%SCALA_VER_MINOR%\classes\
 
-IF javac_version_minor LSS 8 (
-  echo You need to install javac version 1.7 or greater!
-  echo Current javac version is %javac_version
-  GOTO :EOF
-)
-
-SET nailgun_installed=0
-
-where ng > nul 2>&1
-
-if ERRORLEVEL 1 (
-  ECHO You need to install Nailgun to make CBT slightly faster. > nul 2>&1
-) ELSE ( SET nailgun_installed=1 )
-
-where ng-server > nul 2>&1
-
-if ERRORLEVEL 1 (
-    ECHO You need to install Nailgun Server to make CBT slightly faster.
-) ELSE ( SET nailgun_installed=1 )
-
-IF %nailgun_installed%==0 ECHO Note: nailgun not found. It makes CBT faster! > nul 2>&1
-
-where gpg > nul 2>&1
-SET gpg_installed=0
-if ERRORLEVEL 1 (
-    ECHO You need to install gpg for login.
-) ELSE ( SET gpg_installed=0 )
-
-
-
+SET NG_SERVER_JAR=ng-server.jar
 SET NAILGUN_PORT=4444
 SET NG=ng --nailgun-port %NAILGUN_PORT%
+SET NAILGUN=%CBT_HOME%\nailgun_launcher
+SET NAILGUN_TARGET=%NAILGUN%\%TARGET%
+SET NAILGUN_INDICATOR=%NAILGUN_TARGET%..\classes.last-success
+SET NAILGUN_OUT=%NAILGUN_TARGET%nailgun.stdout.log
+SET NAILGUN_ERR=%NAILGUN_TARGET%nailgun.strerr.log
+MD %NAILGUN_TARGET%
 
-for /f "delims=" %%i in ('chdir') do SET CWD=%%i
+REM - CWD current working directory
+FOR /f "delims=" %%i IN ('cd') DO SET CWD=%%i
 
-SET CBT_HOME=%~dp0
+SET CBT_LOOP_FILE=%CWD%\target\.cbt-loop.tmp
+SET CBT_KILL_FILE=%CWD%\target\.cbt-kill.tmp
 
-SET SCALA_VERSION=2.11.8
+SET USER_PRESSED_CTRL_C=130
+REM </ INIT >
 
-SET NAILGUN=%CBT_HOME%nailgun_launcher\
-SET STAGE1=%CBT_HOME%stage1\
-SET TARGET=target\scala-2.11\classes\
 
-mkdir %NAILGUN%%TARGET% > nul 2>&1
-mkdir %STAGE1%%TARGET%  > nul 2>&1
-
-SET nailgun_out=%NAILGUN%\target\nailgun.stdout.log
-SET nailgun_err=%NAILGUN%\target\nailgun.strerr.log
-
-where nc > nul 2>&1
-
-SET nc_installed=1
-SET server_up=0
-
-IF ERRORLEVEL 1 (
-    ECHO Note: nc not found. It will make slightly startup faster.
-) ELSE ( 
-  nc -z -n -w 1 127.0.0.1 %NAILGUN_PORT% > nul 2>&1
-  SET server_up=1
-)
-
-IF "%1%"=="kill" (
-  echo Stopping nailgun 1>&2
-  %NG% ng-stop >> %nailgun_out 2>> %nailgun_err%
+REM < JAVA >
+WHERE javac > NUL 2>&1
+IF %ERRORLEVEL% NEQ 0 (
+  ECHO You need to install javac! CBT needs it to bootstrap from Java sources into Scala.
   GOTO :EOF
 )
 
-SET use_nailgun=1
+REM - ensure that javac >= 1.7.x
+FOR /F "tokens=2" %%i IN ('javac -version 2^>^&1') DO ( SET javac_ver=%%i )
+FOR /F "delims=. tokens=1-3" %%v IN ("%javac_ver%") DO (
+  SET javac_ver_major=%%v
+  SET javac_ver_minor=%%w
+  SET javac_ver_build=%%x
+)
+IF javac_ver_minor LSS 8 (
+  ECHO You need to install javac version 1.7 or greater!
+  ECHO Current javac version is %javac_ver%
+  GOTO :EOF
+)
+REM </ JAVA >
 
-SET res=0
-IF %nailgun_installed%==0 SET res=1
-IF "%1%"=="publishSigned" SET res=1
-IF "%2%"=="publishSigned" SET res=1
-IF "%1%"=="direct"        SET res=1
-IF "%2%"=="direct"      SET res=1
 
-IF %res%==1 SET use_nailgun=0
+REM < NAILGUN >
+SET nailgun_installed=0
+WHERE ng > NUL 2>&1
+IF %ERRORLEVEL% NEQ 0 (
+  SET nailgun_installed=1
+  ECHO You need to install Nailgun to make CBT slightly faster. > NUL 2>&1
+)
+WHERE %NG_SERVER_JAR% > NUL 2>&1
+IF %ERRORLEVEL% NEQ 0 (
+  SET nailgun_installed=1
+  ECHO You need to install Nailgun Server to make CBT slightly faster.  
+)
+REM </ NAILGUN >
 
-REM  IF NOT %server_up%==1
-REM >> %nailgun_out 2>> %nailgun_err
-IF %use_nailgun%==1 (
-  REM try to start nailgun-server, just in case it's not up
-  START ng-server 127.0.0.1:%NAILGUN_PORT%  
+
+REM < GPG >
+SET gpg_installed=0
+WHERE gpg > NUL 2>&1
+IF %ERRORLEVEL% NEQ 0 (
+  SET gpg_installed=1
+  ECHO You need to install gpg for login.
+)
+REM </ GPG >
+
+
+REM < NCAT >
+SET nc_installed=0
+WHERE ncat > NUL 2>&1
+IF %ERRORLEVEL% NEQ 0 (
+  SET nc_installed=1
+  ECHO (Note: ncat not found. It will make slightly startup faster.)
 )
 
-:RUN
-  CALL :stage1 %*
-  IF NOT "%1%"=="loop" (
-    GOTO :EOF
+SET server_up=1
+IF nc_installed EQU 0 (
+  ncat -z -n -w 1 127.0.0.1 %NAILGUN_PORT% > NUL 2>&1
+  SET server_up=%ERRORLEVEL%
+)
+REM </ NCAT >
+
+
+REM < MAIN >
+ECHO [DEBUG] entered main
+CALL :set_debug %*
+if not "%debug%"=="" shift
+
+SET JAVA_OPTS_CBT=%debug% -Xmx1536m -Xss10M "-XX:MaxJavaStackTraceDepth=-1" -XX:+TieredCompilation "-XX:TieredStopAtLevel=1" -Xverify:none
+
+
+IF /I "%~1"=="kill" (
+  ECHO Stopping background process (nailgun^)
+  %NG% ng-stop >> "%NAILGUN_OUT%" 2>> "%NAILGUN_ERR%"
+  REM EXIT 1
+  GOTO :EOF
+)
+
+SET use_nailgun=0
+IF /I "%~1"=="direct" (
+	SET use_nailgun=1
+	SHIFT
+)
+
+SET loop=1
+IF /I "%~1"=="loop" (
+	SET loop=0
+	SHIFT
+)
+
+SET clear_screen=1
+IF /I "%~1"=="clear" (
+	SET clear_screen=0
+	SHIFT
+)
+
+REM there is no OR operator for batch scripts...
+IF %nailgun_installed% EQU 1  SET use_nailgun=1
+IF /I "%~1"=="publishSigned"  SET use_nailgun=1
+
+REM there is no AND operator for batch scripts...
+IF %use_nailgun% EQU 0 (
+  IF %server_up% EQU 0 (
+    IF NOT "%debug%"=="" (
+      ECHO Cant use `-debug` (without `direct`^) when nailgun is already running. 
+      ECHO   If you started it up with `-debug` you can still connect to it. Otherwise use `cbt kill` to kill it.
+      GOTO :EOF
+    )
   ) ELSE (
-    GOTO :RUN
-    echo "======= Restarting CBT =======" 1>&2
+    CALL :log "Starting background process (nailgun)" %*
+    REM try to start nailgun-server, just in case it's not up
+    java %options% %JAVA_OPTS_CBT% -jar %NG_SERVER_JAR% 127.0.0.1:%NAILGUN_PORT% >> %nailgun_out% 2>> %nailgun_err%
+     
+    echo STARTAnje nailguna
+    IF NOT "%debug%"=="" (
+      ECHO "Started nailgun server in debug mode"
+      GOTO :EOF
+    )
   )
+)
 
+REM - need fswatch for loop command
+if %loop% equ 0 (
+	WHERE fswatch > NUL 2>&1
+  IF %ERRORLEVEL% NEQ 0 (
+		echo "Please install fswatch to use cbt loop"
+		GOTO :EOF
+	)
+)
+
+:main_loop_while
+  ECHO [DEBUG] entered main_loop_while
+	if %clear_screen% EQU 0 ( CLS )
+  
+	if exist %CBT_LOOP_FILE% ( DEL %CBT_LOOP_FILE% )
+  
+	if exist %CBT_KILL_FILE% ( DEL %CBT_KILL_FILE% )
+  
+	CALL :stage1 %*
+  
+	if not %loop% equ 0 (
+    CALL :log "not looping, exiting" %*
+    GOTO :END
+  )
+  REM - exit_code is set in stage1
+  if %exit_code% EQU %USER_PRESSED_CTRL_C% (
+		CALL :log "not looping, exiting" %*
+    GOTO :END
+  )
+  
+  REM nailgun_sources is set in stage1
+  for file in "%nailgun_sources%" DO (
+    echo "%file%" >> "%CBT_LOOP_FILE%"
+  )
+  SET files=
+  if exist "%CBT_LOOP_FILE%" (
+    SET files=(sort "%CBT_LOOP_FILE%")
+  )
+  
+  SET pids=
+  if exist "%CBT_KILL_FILE%" (
+    REM FIXME: should we uniq here?
+    SET pids=(type "%CBT_KILL_FILE%") 
+    REM DEL %CBT_LOOP_FILE%
+  )
+  echo ""
+  echo "Watching for file changes... (Ctrl+C short press for loop, long press for abort)"
+  for %%f in "%files%" DO (
+    if %%f=="" ( echo warning: empty file found in loop file list )
+  )
+  fswatch --one-event "%files%"
+  for %%p in "%pids%" DO (
+    if %%p=="" ( echo warning: empty pid found in pid kill list )
+    else (
+      CALL :log "killing process %%p"
+      kill -KILL %%p
+    )
+  )
+GOTO :main_loop_while
+
+GOTO :END
+REM </ MAIN >
+
+
+REM < FUNCTIONS >
+
+REM first stage of CBT
 :stage1
-SETLOCAL
-SET NAILGUN_INDICATOR=%NAILGUN%%TARGET%cbt\NailgunLauncher.class
-SET changed=0
-
-IF EXIST %NAILGUN_INDICATOR% (
-  REM this should recompile nailgun_launcher/ if any .java file is newer than NailgunLauncher.class, FIXME doesn't work
-  FOR %%i IN (%NAILGUN%*.java) DO (
-    FOR /F %%z IN ('DIR /B /O:D %%i%% %NAILGUN_INDICATOR% 2^> nul') DO SET NEWEST=%%z
-    if "%NEWEST:~-4%"=="java" ( SET changed=1 )
-  )
-) ELSE (
-  SET changed=1
-)
-
-IF %changed%==1 (
-  REM defensive delete of potentially broken class files
-  REM DEL /s /q /f %NAILGUN%%TARGET%cbt\*.class > nul 2>&1 
-
-  echo Compiling cbt/nailgun_launcher
+  ECHO [DEBUG] entered stage1
+	CALL :log "Checking for changes in cbt\nailgun_launcher" %*
+	
+	SET changed=1
+	SET nailgun_sources=%NAILGUN%\src\cbt\*.java %CBT_HOME%\libraries\common-0\src\cbt\reflect\*.java
   
-  dir /B /A:-D %NAILGUN%\*.java > %CBT_HOME%temp.txt
-  
-  FOR /F "tokens=*" %%j in (%CBT_HOME%temp.txt) do SET "files=!files! %NAILGUN%%%j"
-
-  javac -Xlint:deprecation -d %NAILGUN%%TARGET% !files!
-
-  IF ERRORLEVEL 1 (
-    REM triggers recompilation next time.
-    DEL %NAILGUN%TARGET/cbt/*.class 2> NUL REM triggers recompilation next time.
-    GOTO :eof
+  for %%f in (%NAILGUN_INDICATOR%) do (
+    CALL :date_to_yyyy_mm_dd "%%~tf"
+    SET ng_ind_last_mod=!date_formatted!
   )
   
-  IF %use_nailgun%==0 (
-    REM echo "Stopping nailgun" 1>&2
-    %NG% ng-stop >> %nailgun_out% 2>> %nailgun_err%
-    REM echo "Restarting nailgun" 1>&2
-    ng-server 127.0.0.1:%NAILGUN_PORT% >> %nailgun_out% 2>> %nailgun_err%
+  for %%f in (%nailgun_sources%) do (
+    CALL :date_to_yyyy_mm_dd "%%~tf"
+    SET ng_source_last_mod=!date_formatted!
+    if "!ng_source_last_mod!" GTR "!ng_ind_last_mod!" ( SET changed=0 )
   )
-)
+  
+	SET exit_code=0
+	if %changed% EQU 0 (
+		echo Stopping background process (nailgun^) if running
+		%NG% ng-stop >> %nailgun_out% 2>> %nailgun_err%
+		REM DEL %NAILGUN_TARGET%cbt\*.class 2>NUL
+    REM defensive delete of potentially broken class files
+		echo Compiling cbt\nailgun_launcher
+		javac -Xlint:deprecation -Xlint:unchecked -d %NAILGUN_TARGET% %nailgun_sources%
+		SET exit_code=%ERRORLEVEL%
+		if %exit_code% EQU 0 (
+			REM touch, set modified
+      copy /b %NAILGUN_INDICATOR% +,, %NAILGUN_INDICATOR%
+			if %use_nailgun% EQU 0 (
+				echo Starting background process (nailgun^)
+				java %options% %JAVA_OPTS_CBT% -jar %NG_SERVER_JAR% 127.0.0.1:%NAILGUN_PORT% >> %nailgun_out% 2>> %nailgun_err%
+				CALL :sleep 1000
+			)
+		)
+	)
 
-REM TODO 0.0 should be replaced by actual spent time, see ./cbt
-IF %use_nailgun%==0 java %JAVA_OPTS% -Xmx6072m -Xss10M -XX:+TieredCompilation -XX:TieredStopAtLevel=1 -Xverify:none -cp %NAILGUN%%TARGET% cbt.NailgunLauncher 0.0 %CWD% %*
-IF %use_nailgun%==0 GOTO :ENDIF
+	CALL :log "run CBT and loop if desired. This allows recompiling CBT itself as part of compile looping." %*
 
-SET /A counter=0
-:BEGINFOR
-REM ECHO %counter%
-IF /I "%counter%" EQU "10" GOTO :ENDFOR
-%NG% ng-cp %NAILGUN%%TARGET%
-%NG% cbt.NailgunLauncher check-alive
-%NG% ng-cp %NAILGUN%%TARGET% >> %nailgun_out% 2>> %nailgun_err%
-%NG% cbt.NailgunLauncher check-alive >> %nailgun_out% 2>> %nailgun_err%
+	if not %exit_code% EQU 0 ( GOTO :EOF )
+  
+  if not %use_nailgun% EQU 0 (
+    CALL :log "Running JVM directly" %*
+    SET options=%JAVA_OPTS%
+    
+    ECHO [DEBUG] options %options%
+    ECHO [DEBUG] JAVA_OPTS_CBT %JAVA_OPTS_CBT%
+    ECHO [DEBUG] NAILGUN_TARGET %NAILGUN_TARGET%
+    ECHO [DEBUG] time_taken %time_taken%
+    ECHO [DEBUG] CWD %CWD%
+    ECHO [DEBUG] loop %loop%
+    ECHO [DEBUG] all args %*
+    
+    REM JVM options to improve startup time. See https://github.com/cvogt/cbt/pull/262
+    java %options% %JAVA_OPTS_CBT% -cp %NAILGUN_TARGET% cbt.NailgunLauncher %time_taken% %CWD% %loop% %*
+    SET exit_code=%ERRORLEVEL%
+  ) else (
+    CALL :log "Running via background process (nailgun)" %*
+    for /L %%i in (0,1,9) do (
+      CALL :log "Adding classpath." %*
+      %NG% ng-cp %NAILGUN_TARGET% >> %nailgun_out% 2>> %nailgun_err%
+      CALL :log "Checking if nailgun is up yet." %*
+      %NG% cbt.NailgunLauncher check-alive >> %nailgun_out% 2>> %nailgun_err%
+      SET alive=%ERRORLEVEL%
+      if "%alive%"=="33" (
+        REM 33 is sent by NailgunLauncher on success
+        REM if Nailgun can't launch the class, it's returning
+        REM 133 which triggers the else branch
+        GOTO :break_for
+      ) else (
+        CALL :log "Nope. Sleeping for 0.2 seconds" %*
+        REM if %%i GTT 1  (
+        REM	echo Waiting for nailgun to start... 
+        REM   (In case of problems try -Dlog=nailgun or check logs in cbt\nailgun_launcher\target\*.log^)
+        REM )
+      )
+      CALL :sleep 200
+    )
+    :break_for
+    if %%i EQU 9 (
+      echo Nailgun call failed. Try 'cbt kill' and check the error log cbt\nailgun_launcher\target\nailgun.stderr.log
+      REM exit %alive%
+      GOTO :EOF
+    )
+    CALL :log "Running CBT via Nailgun." %*
+    %NG% cbt.NailgunLauncher %time_taken% %CWD% %loop% %*
+    SET exit_code=%ERRORLEVEL%
+  )
+  CALL :log "Done running CBT." %*
+	
+GOTO :EOF
 
-SET isAlive=0
-IF %errorlevel%==131 SET isAlive=1
-IF %errorlevel%==33  SET isAlive=1
+REM - sets debug parameters
+:set_debug
+  SET debug=
+  :set_debug_while
+    REM [%1]==[] tests if %1==null
+    if not [%1]==[] (
+      if "%~1"=="-debug" (
+        SET debug="-agentlib:jdwp=transport=dt_socket,server=y,suspend=y,address=5005"
+      ) else if "%~1"=="-Dlog=nailgun" (
+        SET nailgun_out=2
+        SET nailgun_err=2
+      ) else if "%~1"=="-Dlog=all" (
+        SET nailgun_out=2
+        SET nailgun_err=2
+      )
+      shift
+      goto :set_debug_while
+    )
+GOTO :EOF
+
+REM utility function to log message to stderr with stating the time
+:log
+	SET msg=%1
+  REM strip "
+  SET msg=%msg:"=%
+  
+	SET enabled=1
+  :log_while
+    REM [%1]==[] tests if %1==null
+    if not [%1]==[] (
+      REM TODO maybe use string contains: https://stackoverflow.com/a/7006016/4496364
+      SET param=%~1
+      if "%param%"=="-Dlog=time"  (	SET enabled=0	)
+      if "%param%"=="-Dlog=bash"  (	SET enabled=0	)
+      if "%param%"=="-Dlog=all"   (	SET enabled=0	)
+      REM if not "x!param:-Dlog=!"=="x!param!" (
+      REM   if not "x!param:time=!"=="x!param!" (	SET enabled=0	)
+      REM   if not "x!param:bash=!"=="x!param!" (	SET enabled=0	)
+      REM   if not "x!param:all=!"=="x!param!"  ( SET enabled=0	)
+      REM )
+      shift
+      goto :log_while
+    )
+	if %enabled% EQU 0 (
+		SET delta=1
+    REM TODO delta=$(time_taken)
+		echo [%delta%] %msg%
+	)
+GOTO :EOF
+
+REM 02.12.2017. 22:25  -> 2017.12.02. 22:25
+:date_to_yyyy_mm_dd
+SET d=%1
+REM strip "
+set d=%d:"=%
+SET date_formatted=%d:~6,5%%d:~3,3%%d:~0,3%%d:~11,6%
+GOTO :EOF
+
+REM https://stackoverflow.com/a/735294/4496364
+:sleep
+SET sleep_millis=%1
+ping 192.0.2.2 -n 1 -w %sleep_millis% > nul
+GOTO :EOF
+
+REM </ FUNCTIONS >
 
 
-REM IF ERRORLEVEL 1 (
-  REM ECHO Waiting for nailgun
-REM ) ELSE (
-  REM GOTO :ENDFOR 
-REM )
-
-SLEEP 2
-SET /A counter=%counter% + 1
-REM GOTO :BEGINFOR
-:ENDFOR
-%NG% cbt.NailgunLauncher %CWD% %*
+:END
+CALL :log "Exiting CBT" %*
 ENDLOCAL
-:ENDIF
-:ENDPROGRAM
-ENDLOCAL
-REM DEL %CBT_HOME%temp.txt > NUL 1>&2
+REM exit %exit_code%

--- a/cbt.bat
+++ b/cbt.bat
@@ -1,23 +1,24 @@
 @ECHO OFF
+
 REM Launcher batch script that bootstraps CBT from source.
 REM Some of the code for reporting missing dependencies and waiting for nailgun to come up is a bit weird.
 REM This is inentionally kept as small as posible.
-REM Welcomed improvements to this file:
+REM Welcomed improvements:
 REM - reduce code size through better ideas
 REM - reduce code size by moving more of this into type-checked Java/Scala code (if possible without performance loss).
 REM - reduction of dependencies
 REM - performance improvements
 
-REM optional dependencies: 
-REM - ncat      https://nmap.org/
-REM - nailgun   http://martiansoftware.com/nailgun/
+REM optional dependencies:
+REM - ncat        https://nmap.org/
+REM - nailgun     http://martiansoftware.com/nailgun/
+REM - inotifywait https://github.com/thekid/inotify-win
 
 REM 0 is true, 1 is false
 
-REM TODO 
+REM TODO
 REM   time_taken function
-REM   fswatch
-REM   kill
+REM   separate log files for commands different from nailgun server
 
 
 SETLOCAL EnableExtensions EnableDelayedExpansion
@@ -29,17 +30,24 @@ SET SCALA_VER_MAJOR=2
 SET SCALA_VER_MINOR=11
 SET SCALA_VER_BUILD=8
 
-SET TARGET=target\scala-%SCALA_VER_MAJOR%.%SCALA_VER_MINOR%\classes\
+SET TARGET_SCALA=target\scala-%SCALA_VER_MAJOR%.%SCALA_VER_MINOR%
+SET TARGET=%TARGET_SCALA%\classes\
 
-SET NG_SERVER_JAR=ng-server.jar
+
 SET NAILGUN_PORT=4444
 SET NG=ng --nailgun-port %NAILGUN_PORT%
 SET NAILGUN=%CBT_HOME%\nailgun_launcher
 SET NAILGUN_TARGET=%NAILGUN%\%TARGET%
-SET NAILGUN_INDICATOR=%NAILGUN_TARGET%..\classes.last-success
-SET NAILGUN_OUT=%NAILGUN_TARGET%nailgun.stdout.log
-SET NAILGUN_ERR=%NAILGUN_TARGET%nailgun.strerr.log
-MD %NAILGUN_TARGET%
+SET NAILGUN_INDICATOR=%NAILGUN%\%TARGET_SCALA%\classes.last-success
+SET nailgun_out=%NAILGUN_TARGET%nailgun.stdout.log
+SET nailgun_err=%NAILGUN_TARGET%nailgun.stderr.log
+
+IF NOT EXIST %NAILGUN_TARGET% ( MD %NAILGUN_TARGET% )
+IF NOT EXIST %NAILGUN_INDICATOR% ( type nul > %NAILGUN_INDICATOR% )
+
+
+REM - ng-server.jar absolute path
+FOR /F "tokens=*" %%x in ('where ng-server.jar') DO SET NG_SERVER_JAR=%%x
 
 REM - CWD current working directory
 SET "CWD=%cd%"
@@ -54,7 +62,7 @@ REM </ INIT >
 REM < JAVA >
 WHERE javac > NUL 2>&1
 IF %ERRORLEVEL% NEQ 0 (
-  ECHO You need to install javac! CBT needs it to bootstrap from Java sources into Scala.
+  ECHO You must install javac! CBT needs it to bootstrap from Java sources into Scala.
   GOTO :EOF
 )
 
@@ -66,7 +74,7 @@ FOR /F "delims=. tokens=1-3" %%v IN ("%javac_ver%") DO (
   SET javac_ver_build=%%x
 )
 IF javac_ver_minor LSS 8 (
-  ECHO You need to install javac version 1.7 or greater!
+  ECHO You must install javac version 1.7 or greater!
   ECHO Current javac version is %javac_ver%
   GOTO :EOF
 )
@@ -78,22 +86,21 @@ SET nailgun_installed=0
 WHERE ng > NUL 2>&1
 IF %ERRORLEVEL% NEQ 0 (
   SET nailgun_installed=1
-  ECHO You need to install Nailgun to make CBT slightly faster. > NUL 2>&1
+  CALL :log "You can install Nailgun to make CBT slightly faster." %*
 )
-WHERE %NG_SERVER_JAR% > NUL 2>&1
-IF %ERRORLEVEL% NEQ 0 (
+
+IF "%NG_SERVER_JAR%" EQU "" (
   SET nailgun_installed=1
-  ECHO You need to install Nailgun Server to make CBT slightly faster.  
+  CALL :log "You can install Nailgun Server to make CBT slightly faster." %*
 )
 REM </ NAILGUN >
-
 
 REM < GPG >
 SET gpg_installed=0
 WHERE gpg > NUL 2>&1
 IF %ERRORLEVEL% NEQ 0 (
   SET gpg_installed=1
-  ECHO You need to install gpg for login.
+  CALL :log "You need to install gpg for login." %*
 )
 REM </ GPG >
 
@@ -103,67 +110,68 @@ SET nc_installed=0
 WHERE ncat > NUL 2>&1
 IF %ERRORLEVEL% NEQ 0 (
   SET nc_installed=1
-  ECHO (Note: ncat not found. It will make slightly startup faster.)
+  CALL :log "(Note: ncat not found. It will make slightly startup faster.)" %*
 )
 
 SET server_up=1
-IF nc_installed EQU 0 (
+IF %nc_installed% EQU 0 (
   ncat -z -n -w 1 127.0.0.1 %NAILGUN_PORT% > NUL 2>&1
-  SET server_up=%ERRORLEVEL%
+  SET server_up=!ERRORLEVEL!
 )
 REM </ NCAT >
 
 
 REM < MAIN >
 CALL :set_debug %*
-if not "%debug%"=="" shift
+IF NOT "%debug%"=="" SHIFT
 
 SET JAVA_OPTS_CBT=%debug% -Xmx1536m -Xss10M "-XX:MaxJavaStackTraceDepth=-1" -XX:+TieredCompilation "-XX:TieredStopAtLevel=1" -Xverify:none
 
 
 IF /I "%~1"=="kill" (
   ECHO Stopping background process (nailgun^)
-  %NG% ng-stop >> "%NAILGUN_OUT%" 2>> "%NAILGUN_ERR%"
-  REM EXIT 1
+  REM TODO >> "%NAILGUN_OUT%" 2>> "%NAILGUN_ERR%"
+  %NG% ng-stop
   GOTO :EOF
 )
 
 SET use_nailgun=0
-IF /I "%~1"=="direct" (
-	SET use_nailgun=1
-	SHIFT
-)
-
 SET loop=1
-IF /I "%~1"=="loop" (
-	SET loop=0
-	SHIFT
-)
-
 SET clear_screen=1
-IF /I "%~1"=="clear" (
-	SET clear_screen=0
-	SHIFT
+
+REM https://superuser.com/questions/743197/how-to-shift-all-parameters-in-a-batch
+SET "jvmArgs="
+
+REM https://stackoverflow.com/a/3981086/4496364
+:parse_args
+IF NOT [%1]==[] (
+  IF /I "%~1"=="direct" ( SET use_nailgun=1 ) ELSE (
+    IF /I "%~1"=="loop" ( SET loop=0 ) ELSE (
+      IF /I "%~1"=="clear" ( SET clear_screen=0 ) ELSE (
+        SET ^"jvmArgs=%jvmArgs% %1"
+      )
+    )
+  )
+  SHIFT
+  GOTO :parse_args
 )
 
-REM there is no OR operator for batch scripts...
-IF %nailgun_installed% EQU 1  SET use_nailgun=1
-IF /I "%~1"=="publishSigned"  SET use_nailgun=1
+IF %nailgun_installed% EQU 1 ( SET use_nailgun=1 )
+IF /I "%~1"=="publishSigned" ( SET use_nailgun=1 )
 
 REM there is no AND operator for batch scripts...
 IF %use_nailgun% EQU 0 (
   IF %server_up% EQU 0 (
     IF NOT "%debug%"=="" (
-      ECHO Cant use `-debug` (without `direct`^) when nailgun is already running. 
+      ECHO Cant use `-debug` (without `direct`^) when nailgun is already running.
       ECHO   If you started it up with `-debug` you can still connect to it. Otherwise use `cbt kill` to kill it.
       GOTO :EOF
     )
   ) ELSE (
     CALL :log "Starting background process (nailgun)" %*
     REM try to start nailgun-server, just in case it's not up
-    java %options% %JAVA_OPTS_CBT% -jar %NG_SERVER_JAR% 127.0.0.1:%NAILGUN_PORT% >> %nailgun_out% 2>> %nailgun_err%
-     
-    echo STARTAnje nailguna
+    START "" java %options% %JAVA_OPTS_CBT% -jar "%NG_SERVER_JAR%" 127.0.0.1:%NAILGUN_PORT% >> %nailgun_out% 2>> %nailgun_err%
+
     IF NOT "%debug%"=="" (
       ECHO "Started nailgun server in debug mode"
       GOTO :EOF
@@ -171,62 +179,64 @@ IF %use_nailgun% EQU 0 (
   )
 )
 
-REM - need fswatch for loop command
-if %loop% equ 0 (
-	WHERE fswatch > NUL 2>&1
+
+REM - need inotifywait for loop command
+IF %loop% EQU 0 (
+	WHERE inotifywait > NUL 2>&1
   IF %ERRORLEVEL% NEQ 0 (
-		echo "Please install fswatch to use cbt loop"
+		ECHO "Please install inotifywait to use cbt loop"
 		GOTO :EOF
 	)
 )
 
 :main_loop_while
-	if %clear_screen% EQU 0 ( CLS )
-  
-	if exist %CBT_LOOP_FILE% ( DEL %CBT_LOOP_FILE% )
-  
-	if exist %CBT_KILL_FILE% ( DEL %CBT_KILL_FILE% )
-  
+
+	IF %clear_screen% EQU 0 ( CLS )
+	IF EXIST %CBT_LOOP_FILE% ( DEL %CBT_LOOP_FILE% )
+	IF EXIST %CBT_KILL_FILE% ( DEL %CBT_KILL_FILE% )
+
 	CALL :stage1 %*
-  
-	if not %loop% equ 0 (
+
+	IF NOT %loop% EQU 0 (
     CALL :log "not looping, exiting" %*
     GOTO :END
   )
+  
   REM - exit_code is set in stage1
-  if %exit_code% EQU %USER_PRESSED_CTRL_C% (
+  IF %exit_code% EQU %USER_PRESSED_CTRL_C% (
 		CALL :log "not looping, exiting" %*
     GOTO :END
   )
-  
+
   REM nailgun_sources is set in stage1
-  for file in "%nailgun_sources%" DO (
-    echo "%file%" >> "%CBT_LOOP_FILE%"
+  FOR %%f IN (%nailgun_sources%) DO (
+    ECHO %%f >> "%CBT_LOOP_FILE%"
   )
-  SET files=
-  if exist "%CBT_LOOP_FILE%" (
-    SET files=(sort "%CBT_LOOP_FILE%")
-  )
-  
+
   SET pids=
-  if exist "%CBT_KILL_FILE%" (
+  IF EXIST "%CBT_KILL_FILE%" (
     REM FIXME: should we uniq here?
-    SET pids=(type "%CBT_KILL_FILE%") 
+    SET pids=(type "%CBT_KILL_FILE%")
     REM DEL %CBT_LOOP_FILE%
-  )
-  echo ""
-  echo "Watching for file changes... (Ctrl+C short press for loop, long press for abort)"
-  for %%f in "%files%" DO (
-    if %%f=="" ( echo warning: empty file found in loop file list )
-  )
-  fswatch --one-event "%files%"
-  for %%p in "%pids%" DO (
-    if %%p=="" ( echo warning: empty pid found in pid kill list )
-    else (
-      CALL :log "killing process %%p"
-      kill -KILL %%p
+    FOR %%p IN (%pids%) DO (
+      IF %%p=="" ( ECHO warning: empty pid found in pid kill list ) ELSE (
+        CALL :log "killing process %%p"
+        TASKKILL /PID %%p /T
+      )
     )
   )
+
+  ECHO "Watching for file changes... (Ctrl+C short press for loop, long press for abort)"
+  SET files=
+  IF EXIST "%CBT_LOOP_FILE%" (
+    REM https://stackoverflow.com/questions/3068929/how-to-read-file-contents-into-a-variable-in-a-batch-file
+    FOR /f "delims=" %%f IN (%CBT_LOOP_FILE%) DO (
+      IF %%f=="" ( ECHO warning: empty file found in loop file list )
+      SET ^"files=!files! %%f"
+    )
+  )
+  inotifywait -q !files!
+
 GOTO :main_loop_while
 
 GOTO :END
@@ -238,36 +248,39 @@ REM < FUNCTIONS >
 REM first stage of CBT
 :stage1
 	CALL :log "Checking for changes in cbt\nailgun_launcher" %*
-	
+
 	SET changed=1
 	SET nailgun_sources=%NAILGUN%\src\cbt\*.java %CBT_HOME%\libraries\common-0\src\cbt\reflect\*.java
-  
-  for %%f in (%NAILGUN_INDICATOR%) do (
+
+  FOR %%f IN (%NAILGUN_INDICATOR%) DO (  
     CALL :date_to_yyyy_mm_dd "%%~tf"
     SET ng_ind_last_mod=!date_formatted!
   )
-  
-  for %%f in (%nailgun_sources%) do (
+
+  FOR %%f IN (%nailgun_sources%) DO (
     CALL :date_to_yyyy_mm_dd "%%~tf"
     SET ng_source_last_mod=!date_formatted!
-    if "!ng_source_last_mod!" GTR "!ng_ind_last_mod!" ( SET changed=0 )
+    
+    IF "!ng_source_last_mod!" GTR "!ng_ind_last_mod!" ( SET changed=0 )
   )
-  
+
 	SET exit_code=0
-	if %changed% EQU 0 (
-		echo Stopping background process (nailgun^) if running
-		%NG% ng-stop >> %nailgun_out% 2>> %nailgun_err%
+	IF %changed% EQU 0 (
+		ECHO Stopping background process (nailgun^) if running
+    REM TODO >> %nailgun_out% 2>> %nailgun_err%
+		%NG% ng-stop 
+    
 		REM DEL %NAILGUN_TARGET%cbt\*.class 2>NUL
     REM defensive delete of potentially broken class files
-		echo Compiling cbt\nailgun_launcher
+		ECHO Compiling cbt\nailgun_launcher
 		javac -Xlint:deprecation -Xlint:unchecked -d %NAILGUN_TARGET% %nailgun_sources%
 		SET exit_code=%ERRORLEVEL%
-		if %exit_code% EQU 0 (
+		IF %exit_code% EQU 0 (
 			REM touch, set modified
-      copy /b %NAILGUN_INDICATOR% +,, %NAILGUN_INDICATOR%
-			if %use_nailgun% EQU 0 (
-				echo Starting background process (nailgun^)
-				java %options% %JAVA_OPTS_CBT% -jar %NG_SERVER_JAR% 127.0.0.1:%NAILGUN_PORT% >> %nailgun_out% 2>> %nailgun_err%
+      COPY /B %NAILGUN_INDICATOR% +,, %NAILGUN_INDICATOR%
+			IF %use_nailgun% EQU 0 (
+				ECHO Starting background process (nailgun^)
+				START "" java %options% %JAVA_OPTS_CBT% -jar %NG_SERVER_JAR% 127.0.0.1:%NAILGUN_PORT% >> %nailgun_out% 2>> %nailgun_err%
 				CALL :sleep 1000
 			)
 		)
@@ -275,113 +288,110 @@ REM first stage of CBT
 
 	CALL :log "run CBT and loop if desired. This allows recompiling CBT itself as part of compile looping." %*
 
-	if not %exit_code% EQU 0 ( GOTO :EOF )
-  
-  if not %use_nailgun% EQU 0 (
+	IF NOT %exit_code% EQU 0 ( GOTO :EOF )
+
+  IF NOT %use_nailgun% EQU 0 (
     CALL :log "Running JVM directly" %*
     SET options=%JAVA_OPTS%
-    
+
     REM JVM options to improve startup time. See https://github.com/cvogt/cbt/pull/262
-    java %options% %JAVA_OPTS_CBT% -cp %NAILGUN_TARGET% cbt.NailgunLauncher %time_taken% %CWD% %loop% %*
+    java %options% %JAVA_OPTS_CBT% -cp %NAILGUN_TARGET% cbt.NailgunLauncher %time_taken% %CWD% %loop% %jvmArgs%
     SET exit_code=%ERRORLEVEL%
-  ) else (
-    CALL :log "Running via background process (nailgun)" %*
-    for /L %%i in (0,1,9) do (
+  ) ELSE (
+    CALL :log "Running via background process (nailgun^)" %*
+    FOR /L %%i IN (0,1,9) DO (
       CALL :log "Adding classpath." %*
-      %NG% ng-cp %NAILGUN_TARGET% >> %nailgun_out% 2>> %nailgun_err%
+      REM TODO >> %nailgun_out% 2>> %nailgun_err%
+      %NG% ng-cp %NAILGUN_TARGET% 
+
       CALL :log "Checking if nailgun is up yet." %*
-      %NG% cbt.NailgunLauncher check-alive >> %nailgun_out% 2>> %nailgun_err%
-      SET alive=%ERRORLEVEL%
-      if "%alive%"=="33" (
-        REM 33 is sent by NailgunLauncher on success
-        REM if Nailgun can't launch the class, it's returning
-        REM 133 which triggers the else branch
+      REM TODO >> %nailgun_out% 2>> %nailgun_err%
+      %NG% cbt.NailgunLauncher check-alive
+      SET alive=!ERRORLEVEL!
+
+      IF "!alive!"=="33" (
+        REM 33  is returned by NailgunLauncher on success
+        REM 133 is returned by NailgunLauncher if it can't launch the class
         GOTO :break_for
-      ) else (
+      ) ELSE (
         CALL :log "Nope. Sleeping for 0.2 seconds" %*
-        REM if %%i GTT 1  (
-        REM	echo Waiting for nailgun to start... 
-        REM   (In case of problems try -Dlog=nailgun or check logs in cbt\nailgun_launcher\target\*.log^)
-        REM )
+        REM In case of problems try -Dlog=nailgun or check logs in cbt\nailgun_launcher\target\*.log
       )
       CALL :sleep 200
     )
     :break_for
-    if %%i EQU 9 (
-      echo Nailgun call failed. Try 'cbt kill' and check the error log cbt\nailgun_launcher\target\nailgun.stderr.log
-      REM exit %alive%
+    IF %%i EQU 9 (
+      ECHO Nailgun call failed. Try 'cbt kill' and check the error log cbt\nailgun_launcher\target\nailgun.stderr.log
+      EXIT /B %alive%
       GOTO :EOF
     )
     CALL :log "Running CBT via Nailgun." %*
-    %NG% cbt.NailgunLauncher %time_taken% %CWD% %loop% %*
+    %NG% cbt.NailgunLauncher %time_taken% %CWD% %loop% %jvmArgs%
     SET exit_code=%ERRORLEVEL%
   )
   CALL :log "Done running CBT." %*
-	
+
 GOTO :EOF
 
 REM - sets debug parameters
 :set_debug
   SET debug=
   :set_debug_while
-    REM [%1]==[] tests if %1==null
-    if not [%1]==[] (
-      if "%~1"=="-debug" (
+    REM - [%1]==[] tests if %1==null
+    REM - CON is equiv to bash's /dev/stderr (more like display/console...)
+    REM   https://superuser.com/questions/241272/windows-how-to-redirect-file-parameter-to-stdout-windows-equivalent-of-dev-s
+    IF NOT [%1]==[] (
+      IF "%~1"=="-debug" (
         SET debug="-agentlib:jdwp=transport=dt_socket,server=y,suspend=y,address=5005"
-      ) else if "%~1"=="-Dlog=nailgun" (
-        SET nailgun_out=2
-        SET nailgun_err=2
-      ) else if "%~1"=="-Dlog=all" (
-        SET nailgun_out=2
-        SET nailgun_err=2
+      ) ELSE IF "%~1"=="-Dlog=nailgun" (
+        SET nailgun_out=CON
+        SET nailgun_err=CON
+      ) ELSE IF "%~1"=="-Dlog=all" (
+        SET nailgun_out=CON
+        SET nailgun_err=CON
       )
-      shift
-      goto :set_debug_while
+      SHIFT
+      GOTO :set_debug_while
     )
 GOTO :EOF
 
 REM utility function to log message to stderr with stating the time
 :log
 	SET msg=%1
-  REM strip "
+  REM strip surrounding "
   SET msg=%msg:"=%
-  
+
 	SET enabled=1
   :log_while
-    REM [%1]==[] tests if %1==null
-    if not [%1]==[] (
-      REM TODO maybe use string contains: https://stackoverflow.com/a/7006016/4496364
-      SET param=%~1
-      if "%param%"=="-Dlog=time"  (	SET enabled=0	)
-      if "%param%"=="-Dlog=bash"  (	SET enabled=0	)
-      if "%param%"=="-Dlog=all"   (	SET enabled=0	)
-      REM if not "x!param:-Dlog=!"=="x!param!" (
-      REM   if not "x!param:time=!"=="x!param!" (	SET enabled=0	)
-      REM   if not "x!param:bash=!"=="x!param!" (	SET enabled=0	)
-      REM   if not "x!param:all=!"=="x!param!"  ( SET enabled=0	)
-      REM )
-      shift
-      goto :log_while
+    REM id first parameter is not null
+    IF NOT "%~1"=="" (
+      IF "!param!"=="-Dlog"  (	SET enabled=0	)
+      REM These don't work because of EQUALS sign!
+      REM IF "%param%"=="-Dlog=time"  (	SET enabled=0	)
+      REM IF "%param%"=="-Dlog=bash"  (	SET enabled=0	)
+      REM IF "%param%"=="-Dlog=all"   (	SET enabled=0	)
+      SHIFT
+      GOTO :log_while
     )
-	if %enabled% EQU 0 (
+	IF %enabled% EQU 0 (
 		SET delta=1
     REM delta=$(time_taken)
-		echo [%delta%] %msg%
+		ECHO [%delta%] %msg%
 	)
 GOTO :EOF
 
 REM 02.12.2017. 22:25  -> 2017.12.02. 22:25
 :date_to_yyyy_mm_dd
-SET d=%1
-REM strip "
-set d=%d:"=%
-SET date_formatted=%d:~6,5%%d:~3,3%%d:~0,3%%d:~11,6%
+  SET d=%1
+  REM strip "
+  SET d=%d:"=%
+  SET date_formatted=%d:~6,5%%d:~3,3%%d:~0,3%%d:~11,6%
 GOTO :EOF
 
 REM https://stackoverflow.com/a/735294/4496364
 :sleep
-SET sleep_millis=%1
-ping 192.0.2.2 -n 1 -w %sleep_millis% > nul
+  SET sleep_millis=%1
+  ping 192.0.2.2 -n 1 -w %sleep_millis% > NUL
 GOTO :EOF
 
 REM </ FUNCTIONS >
@@ -390,4 +400,3 @@ REM </ FUNCTIONS >
 :END
 CALL :log "Exiting CBT" %*
 ENDLOCAL
-REM exit %exit_code%

--- a/cbt.bat
+++ b/cbt.bat
@@ -43,8 +43,6 @@ SET nailgun_out=%NAILGUN_TARGET%nailgun.stdout.log
 SET nailgun_err=%NAILGUN_TARGET%nailgun.stderr.log
 
 IF NOT EXIST %NAILGUN_TARGET% ( MD %NAILGUN_TARGET% )
-IF NOT EXIST %NAILGUN_INDICATOR% ( type nul > %NAILGUN_INDICATOR% )
-
 
 REM - ng-server.jar absolute path
 FOR /F "tokens=*" %%x in ('where ng-server.jar') DO SET NG_SERVER_JAR=%%x
@@ -263,6 +261,7 @@ REM first stage of CBT
 
     IF "!ng_source_last_mod!" GTR "!ng_ind_last_mod!" ( SET changed=0 )
   )
+  IF NOT EXIST %NAILGUN_INDICATOR% ( SET changed=0 )
 
   SET exit_code=0
   IF %changed% EQU 0 (

--- a/cbt.bat
+++ b/cbt.bat
@@ -182,29 +182,29 @@ IF %use_nailgun% EQU 0 (
 
 REM - need inotifywait for loop command
 IF %loop% EQU 0 (
-	WHERE inotifywait > NUL 2>&1
+  WHERE inotifywait > NUL 2>&1
   IF %ERRORLEVEL% NEQ 0 (
-		ECHO "Please install inotifywait to use cbt loop"
-		GOTO :EOF
-	)
+    ECHO "Please install inotifywait to use cbt loop"
+    GOTO :EOF
+  )
 )
 
 :main_loop_while
 
-	IF %clear_screen% EQU 0 ( CLS )
-	IF EXIST %CBT_LOOP_FILE% ( DEL %CBT_LOOP_FILE% )
-	IF EXIST %CBT_KILL_FILE% ( DEL %CBT_KILL_FILE% )
+  IF %clear_screen% EQU 0 ( CLS )
+  IF EXIST %CBT_LOOP_FILE% ( DEL %CBT_LOOP_FILE% )
+  IF EXIST %CBT_KILL_FILE% ( DEL %CBT_KILL_FILE% )
 
-	CALL :stage1 %*
+  CALL :stage1 %*
 
-	IF NOT %loop% EQU 0 (
+  IF NOT %loop% EQU 0 (
     CALL :log "not looping, exiting" %*
     GOTO :END
   )
 
   REM - exit_code is set in stage1
   IF %exit_code% EQU %USER_PRESSED_CTRL_C% (
-		CALL :log "not looping, exiting" %*
+    CALL :log "not looping, exiting" %*
     GOTO :END
   )
 
@@ -247,10 +247,10 @@ REM < FUNCTIONS >
 
 REM first stage of CBT
 :stage1
-	CALL :log "Checking for changes in cbt\nailgun_launcher" %*
+  CALL :log "Checking for changes in cbt\nailgun_launcher" %*
 
-	SET changed=1
-	SET nailgun_sources=%NAILGUN%\src\cbt\*.java %CBT_HOME%\libraries\common-0\src\cbt\reflect\*.java
+  SET changed=1
+  SET nailgun_sources=%NAILGUN%\src\cbt\*.java %CBT_HOME%\libraries\common-0\src\cbt\reflect\*.java
 
   FOR %%f IN (%NAILGUN_INDICATOR%) DO (
     CALL :date_to_yyyy_mm_dd "%%~tf"
@@ -264,33 +264,33 @@ REM first stage of CBT
     IF "!ng_source_last_mod!" GTR "!ng_ind_last_mod!" ( SET changed=0 )
   )
 
-	SET exit_code=0
-	IF %changed% EQU 0 (
-		ECHO Stopping background process (nailgun^) if running
+  SET exit_code=0
+  IF %changed% EQU 0 (
+    ECHO Stopping background process (nailgun^) if running
     REM TODO >> %nailgun_out% 2>> %nailgun_err%
-		%NG% ng-stop
+    %NG% ng-stop
 
-		REM DEL %NAILGUN_TARGET%cbt\*.class 2>NUL
+    REM DEL %NAILGUN_TARGET%cbt\*.class 2>NUL
     REM defensive delete of potentially broken class files
-		ECHO Compiling cbt\nailgun_launcher
-		javac -Xlint:deprecation -Xlint:unchecked -d %NAILGUN_TARGET% %nailgun_sources%
-		SET exit_code=%ERRORLEVEL%
-		IF %exit_code% EQU 0 (
-			REM touch, set modified
+    ECHO Compiling cbt\nailgun_launcher
+    javac -Xlint:deprecation -Xlint:unchecked -d %NAILGUN_TARGET% %nailgun_sources%
+    SET exit_code=%ERRORLEVEL%
+    IF %exit_code% EQU 0 (
+      REM touch, set modified
       IF NOT EXIST %NAILGUN_INDICATOR% ( type nul > %NAILGUN_INDICATOR% ) ELSE (
         COPY /B %NAILGUN_INDICATOR% +,, %NAILGUN_INDICATOR%
       )
-			IF %use_nailgun% EQU 0 (
-				ECHO Starting background process (nailgun^)
-				START "" java %options% %JAVA_OPTS_CBT% -jar %NG_SERVER_JAR% 127.0.0.1:%NAILGUN_PORT% >> %nailgun_out% 2>> %nailgun_err%
-				CALL :sleep 1000
-			)
-		)
-	)
+      IF %use_nailgun% EQU 0 (
+        ECHO Starting background process (nailgun^)
+        START "" java %options% %JAVA_OPTS_CBT% -jar %NG_SERVER_JAR% 127.0.0.1:%NAILGUN_PORT% >> %nailgun_out% 2>> %nailgun_err%
+        CALL :sleep 1000
+      )
+    )
+  )
 
-	CALL :log "run CBT and loop if desired. This allows recompiling CBT itself as part of compile looping." %*
+  CALL :log "run CBT and loop if desired. This allows recompiling CBT itself as part of compile looping." %*
 
-	IF NOT %exit_code% EQU 0 ( GOTO :EOF )
+  IF NOT %exit_code% EQU 0 ( GOTO :EOF )
 
   IF NOT %use_nailgun% EQU 0 (
     CALL :log "Running JVM directly" %*
@@ -359,28 +359,28 @@ GOTO :EOF
 
 REM utility function to log message to stderr with stating the time
 :log
-	SET msg=%1
+  SET msg=%1
   REM strip surrounding "
   SET msg=%msg:"=%
 
-	SET enabled=1
+  SET enabled=1
   :log_while
     REM id first parameter is not null
     IF NOT "%~1"=="" (
       SET param=%~1
-      IF "!param!"=="-Dlog"  (	SET enabled=0	)
+      IF "!param!"=="-Dlog"  (  SET enabled=0  )
       REM These don't work because of EQUALS sign!
-      REM IF "%param%"=="-Dlog=time"  (	SET enabled=0	)
-      REM IF "%param%"=="-Dlog=bash"  (	SET enabled=0	)
-      REM IF "%param%"=="-Dlog=all"   (	SET enabled=0	)
+      REM IF "%param%"=="-Dlog=time"  (  SET enabled=0  )
+      REM IF "%param%"=="-Dlog=bash"  (  SET enabled=0  )
+      REM IF "%param%"=="-Dlog=all"   (  SET enabled=0  )
       SHIFT
       GOTO :log_while
     )
-	IF %enabled% EQU 0 (
-		SET delta=1
+  IF %enabled% EQU 0 (
+    SET delta=1
     REM delta=$(time_taken)
-		ECHO [%delta%] %msg%
-	)
+    ECHO [%delta%] %msg%
+  )
 GOTO :EOF
 
 REM 02.12.2017. 22:25  -> 2017.12.02. 22:25

--- a/cbt.bat
+++ b/cbt.bat
@@ -14,10 +14,15 @@ REM - nailgun   http://martiansoftware.com/nailgun/
 
 REM 0 is true, 1 is false
 
+REM TODO 
+REM   time_taken function
+REM   fswatch
+REM   kill
+REM
+
 SETLOCAL EnableExtensions EnableDelayedExpansion
 
 REM < INIT >
-REM TODO 
 SET time_taken=1.1
 
 SET SCALA_VER_MAJOR=2
@@ -110,7 +115,6 @@ REM </ NCAT >
 
 
 REM < MAIN >
-ECHO [DEBUG] entered main
 CALL :set_debug %*
 if not "%debug%"=="" shift
 
@@ -177,7 +181,6 @@ if %loop% equ 0 (
 )
 
 :main_loop_while
-  ECHO [DEBUG] entered main_loop_while
 	if %clear_screen% EQU 0 ( CLS )
   
 	if exist %CBT_LOOP_FILE% ( DEL %CBT_LOOP_FILE% )
@@ -234,7 +237,6 @@ REM < FUNCTIONS >
 
 REM first stage of CBT
 :stage1
-  ECHO [DEBUG] entered stage1
 	CALL :log "Checking for changes in cbt\nailgun_launcher" %*
 	
 	SET changed=1
@@ -278,14 +280,6 @@ REM first stage of CBT
   if not %use_nailgun% EQU 0 (
     CALL :log "Running JVM directly" %*
     SET options=%JAVA_OPTS%
-    
-    ECHO [DEBUG] options %options%
-    ECHO [DEBUG] JAVA_OPTS_CBT %JAVA_OPTS_CBT%
-    ECHO [DEBUG] NAILGUN_TARGET %NAILGUN_TARGET%
-    ECHO [DEBUG] time_taken %time_taken%
-    ECHO [DEBUG] CWD %CWD%
-    ECHO [DEBUG] loop %loop%
-    ECHO [DEBUG] all args %*
     
     REM JVM options to improve startup time. See https://github.com/cvogt/cbt/pull/262
     java %options% %JAVA_OPTS_CBT% -cp %NAILGUN_TARGET% cbt.NailgunLauncher %time_taken% %CWD% %loop% %*
@@ -371,7 +365,7 @@ REM utility function to log message to stderr with stating the time
     )
 	if %enabled% EQU 0 (
 		SET delta=1
-    REM TODO delta=$(time_taken)
+    REM delta=$(time_taken)
 		echo [%delta%] %msg%
 	)
 GOTO :EOF

--- a/cbt.bat
+++ b/cbt.bat
@@ -245,14 +245,12 @@ REM first stage of CBT
   for %%f in (%NAILGUN_INDICATOR%) do (
     CALL :date_to_yyyy_mm_dd "%%~tf"
     SET ng_ind_last_mod=!date_formatted!
-    ECHO ng_indicator %%f
   )
   
   for %%f in (%nailgun_sources%) do (
     CALL :date_to_yyyy_mm_dd "%%~tf"
     SET ng_source_last_mod=!date_formatted!
     if "!ng_source_last_mod!" GTR "!ng_ind_last_mod!" ( SET changed=0 )
-    ECHO nailgun_source %%f
   )
   
 	SET exit_code=0

--- a/cbt.bat
+++ b/cbt.bat
@@ -201,7 +201,7 @@ IF %loop% EQU 0 (
     CALL :log "not looping, exiting" %*
     GOTO :END
   )
-  
+
   REM - exit_code is set in stage1
   IF %exit_code% EQU %USER_PRESSED_CTRL_C% (
 		CALL :log "not looping, exiting" %*
@@ -252,7 +252,7 @@ REM first stage of CBT
 	SET changed=1
 	SET nailgun_sources=%NAILGUN%\src\cbt\*.java %CBT_HOME%\libraries\common-0\src\cbt\reflect\*.java
 
-  FOR %%f IN (%NAILGUN_INDICATOR%) DO (  
+  FOR %%f IN (%NAILGUN_INDICATOR%) DO (
     CALL :date_to_yyyy_mm_dd "%%~tf"
     SET ng_ind_last_mod=!date_formatted!
   )
@@ -260,7 +260,7 @@ REM first stage of CBT
   FOR %%f IN (%nailgun_sources%) DO (
     CALL :date_to_yyyy_mm_dd "%%~tf"
     SET ng_source_last_mod=!date_formatted!
-    
+
     IF "!ng_source_last_mod!" GTR "!ng_ind_last_mod!" ( SET changed=0 )
   )
 
@@ -268,8 +268,8 @@ REM first stage of CBT
 	IF %changed% EQU 0 (
 		ECHO Stopping background process (nailgun^) if running
     REM TODO >> %nailgun_out% 2>> %nailgun_err%
-		%NG% ng-stop 
-    
+		%NG% ng-stop
+
 		REM DEL %NAILGUN_TARGET%cbt\*.class 2>NUL
     REM defensive delete of potentially broken class files
 		ECHO Compiling cbt\nailgun_launcher
@@ -277,7 +277,9 @@ REM first stage of CBT
 		SET exit_code=%ERRORLEVEL%
 		IF %exit_code% EQU 0 (
 			REM touch, set modified
-      COPY /B %NAILGUN_INDICATOR% +,, %NAILGUN_INDICATOR%
+      IF NOT EXIST %NAILGUN_INDICATOR% ( type nul > %NAILGUN_INDICATOR% ) ELSE (
+        COPY /B %NAILGUN_INDICATOR% +,, %NAILGUN_INDICATOR%
+      )
 			IF %use_nailgun% EQU 0 (
 				ECHO Starting background process (nailgun^)
 				START "" java %options% %JAVA_OPTS_CBT% -jar %NG_SERVER_JAR% 127.0.0.1:%NAILGUN_PORT% >> %nailgun_out% 2>> %nailgun_err%
@@ -302,7 +304,7 @@ REM first stage of CBT
     FOR /L %%i IN (0,1,9) DO (
       CALL :log "Adding classpath." %*
       REM TODO >> %nailgun_out% 2>> %nailgun_err%
-      %NG% ng-cp %NAILGUN_TARGET% 
+      %NG% ng-cp %NAILGUN_TARGET%
 
       CALL :log "Checking if nailgun is up yet." %*
       REM TODO >> %nailgun_out% 2>> %nailgun_err%
@@ -365,6 +367,7 @@ REM utility function to log message to stderr with stating the time
   :log_while
     REM id first parameter is not null
     IF NOT "%~1"=="" (
+      SET param=%~1
       IF "!param!"=="-Dlog"  (	SET enabled=0	)
       REM These don't work because of EQUALS sign!
       REM IF "%param%"=="-Dlog=time"  (	SET enabled=0	)

--- a/libraries/process/process.scala
+++ b/libraries/process/process.scala
@@ -86,7 +86,7 @@ trait Module {
   private trait CLibrary extends Library {
     def getpid: Int
   }
-  val nativeLib = if(Platform.isWindows()) "msvcrt" else "c"
+  val nativeLib = if ( Platform.isWindows() ) "msvcrt" else "c"
   private val CLibraryInstance: CLibrary = Native.loadLibrary( nativeLib, classOf[CLibrary] ).asInstanceOf[CLibrary]
 
   def currentProcessId: Int = {

--- a/libraries/process/process.scala
+++ b/libraries/process/process.scala
@@ -82,11 +82,12 @@ trait Module {
     f
   }
 
-  import com.sun.jna.{ Library, Native }
+  import com.sun.jna.{ Library, Native, Platform }
   private trait CLibrary extends Library {
     def getpid: Int
   }
-  private val CLibraryInstance: CLibrary = Native.loadLibrary( "c", classOf[CLibrary] ).asInstanceOf[CLibrary]
+  val nativeLib = if(Platform.isWindows()) "msvcrt" else "c"
+  private val CLibraryInstance: CLibrary = Native.loadLibrary( nativeLib, classOf[CLibrary] ).asInstanceOf[CLibrary]
 
   def currentProcessId: Int = {
     if ( Option( System.getProperty( "os.name" ) ).exists( _.startsWith( "Windows" ) ) ) {

--- a/nailgun_launcher/src/cbt/EarlyDependencies.java
+++ b/nailgun_launcher/src/cbt/EarlyDependencies.java
@@ -5,6 +5,9 @@ import java.nio.file.*;
 import java.net.*;
 import java.security.*;
 import java.util.*;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
 import static cbt.Stage0Lib.*;
 import static cbt.NailgunLauncher.*;
 
@@ -29,17 +32,17 @@ public class EarlyDependencies{
   public EarlyDependencies(
     String mavenCache, String mavenUrl, ClassLoaderCache classLoaderCache, ClassLoader rootClassLoader
   ) throws Throwable {
-    String scalaReflect_2_11_8_File = mavenCache + "/org/scala-lang/scala-reflect/2.11.8/scala-reflect-2.11.8.jar";
-    String scalaCompiler_2_11_8_File = mavenCache + "/org/scala-lang/scala-compiler/2.11.8/scala-compiler-2.11.8.jar";
-    String scalaXml_1_0_6_File = mavenCache + "/org/scala-lang/modules/scala-xml_2.11/1.0.6/scala-xml_2.11-1.0.6.jar";
-    String scalaLibrary_2_11_8_File = mavenCache + "/org/scala-lang/scala-library/2.11.8/scala-library-2.11.8.jar";
-    String zinc_0_3_13_File = mavenCache + "/com/typesafe/zinc/zinc/0.3.13/zinc-0.3.13.jar";
-    String incrementalCompiler_0_13_13_File = mavenCache + "/com/typesafe/sbt/incremental-compiler/0.13.13/incremental-compiler-0.13.13.jar";
-    String compilerInterface_0_13_13_File = mavenCache + "/com/typesafe/sbt/compiler-interface/0.13.13/compiler-interface-0.13.13-sources.jar";
-    String scalaCompiler_2_10_6_File = mavenCache + "/org/scala-lang/scala-compiler/2.10.6/scala-compiler-2.10.6.jar";
-    String sbtInterface_0_13_13_File = mavenCache + "/com/typesafe/sbt/sbt-interface/0.13.13/sbt-interface-0.13.13.jar";
-    String scalaReflect_2_10_6_File = mavenCache + "/org/scala-lang/scala-reflect/2.10.6/scala-reflect-2.10.6.jar";
-    String scalaLibrary_2_10_6_File = mavenCache + "/org/scala-lang/scala-library/2.10.6/scala-library-2.10.6.jar";
+    String scalaReflect_2_11_8_File = mavenCache + pip("/org/scala-lang/scala-reflect/2.11.8/scala-reflect-2.11.8.jar");
+    String scalaCompiler_2_11_8_File = mavenCache + pip("/org/scala-lang/scala-compiler/2.11.8/scala-compiler-2.11.8.jar");
+    String scalaXml_1_0_6_File = mavenCache + pip("/org/scala-lang/modules/scala-xml_2.11/1.0.6/scala-xml_2.11-1.0.6.jar");
+    String scalaLibrary_2_11_8_File = mavenCache + pip("/org/scala-lang/scala-library/2.11.8/scala-library-2.11.8.jar");
+    String zinc_0_3_13_File = mavenCache + pip("/com/typesafe/zinc/zinc/0.3.13/zinc-0.3.13.jar");
+    String incrementalCompiler_0_13_13_File = mavenCache + pip("/com/typesafe/sbt/incremental-compiler/0.13.13/incremental-compiler-0.13.13.jar");
+    String compilerInterface_0_13_13_File = mavenCache + pip("/com/typesafe/sbt/compiler-interface/0.13.13/compiler-interface-0.13.13-sources.jar");
+    String scalaCompiler_2_10_6_File = mavenCache + pip("/org/scala-lang/scala-compiler/2.10.6/scala-compiler-2.10.6.jar");
+    String sbtInterface_0_13_13_File = mavenCache + pip("/com/typesafe/sbt/sbt-interface/0.13.13/sbt-interface-0.13.13.jar");
+    String scalaReflect_2_10_6_File = mavenCache + pip("/org/scala-lang/scala-reflect/2.10.6/scala-reflect-2.10.6.jar");
+    String scalaLibrary_2_10_6_File = mavenCache + pip("/org/scala-lang/scala-library/2.10.6/scala-library-2.10.6.jar");
 
     download(new URL(mavenUrl + "/org/scala-lang/scala-reflect/2.11.8/scala-reflect-2.11.8.jar"), Paths.get(scalaReflect_2_11_8_File), "b74530deeba742ab4f3134de0c2da0edc49ca361");
     download(new URL(mavenUrl + "/org/scala-lang/scala-compiler/2.11.8/scala-compiler-2.11.8.jar"), Paths.get(scalaCompiler_2_11_8_File), "fe1285c9f7b58954c5ef6d80b59063569c065e9a");
@@ -153,5 +156,14 @@ public class EarlyDependencies{
     scalaReflect_File = scalaReflect_2_11_8_File;
     sbtInterface_File = sbtInterface_0_13_13_File;
     compilerInterface_File = compilerInterface_0_13_13_File;
+  }
+  
+  /** Platform independent path.<br>
+   * Replaces slashes with backslashes, e.g. something/bla becomes something\bla on Windows
+   */
+  private String pip(String pathWithSlashes) {
+	  // when replacing the path with \ Java treats it like escape character,
+	  // that's why we need Matcher.quoteReplacement
+	  return pathWithSlashes.replaceAll("/", Matcher.quoteReplacement(File.separator));
   }
 }

--- a/nailgun_launcher/src/cbt/EarlyDependencies.java
+++ b/nailgun_launcher/src/cbt/EarlyDependencies.java
@@ -6,8 +6,6 @@ import java.net.*;
 import java.security.*;
 import java.util.*;
 import java.util.regex.Matcher;
-import java.util.regex.Pattern;
-
 import static cbt.Stage0Lib.*;
 import static cbt.NailgunLauncher.*;
 
@@ -157,13 +155,11 @@ public class EarlyDependencies{
     sbtInterface_File = sbtInterface_0_13_13_File;
     compilerInterface_File = compilerInterface_0_13_13_File;
   }
-  
-  /** Platform independent path.<br>
-   * Replaces slashes with backslashes, e.g. something/bla becomes something\bla on Windows
-   */
-  private String pip(String pathWithSlashes) {
-	  // when replacing the path with \ Java treats it like escape character,
-	  // that's why we need Matcher.quoteReplacement
-	  return pathWithSlashes.replaceAll("/", Matcher.quoteReplacement(File.separator));
+
+  // Replaces slashes with backslashes, e.g. a/b/c becomes a\b\c on Windows
+  private String pip(String unixPath) {
+    // when replacing the path with \ Java treats it like escape character,
+    // that's why we need Matcher.quoteReplacement
+    return unixPath.replaceAll("/", Matcher.quoteReplacement(File.separator));
   }
 }

--- a/nailgun_launcher/src/cbt/NailgunLauncher.java
+++ b/nailgun_launcher/src/cbt/NailgunLauncher.java
@@ -16,6 +16,9 @@ import static java.nio.file.Files.write;
  * dependencies outside the JDK.
  */
 public class NailgunLauncher{
+
+	public static String fSep = File.separator;
+	
   /** Persistent cache for caching classloaders for the JVM life time. */
   private static Map<Object,Object> classLoaderCacheHashMap = new HashMap<Object,Object>();
 
@@ -23,17 +26,17 @@ public class NailgunLauncher{
     = System.getSecurityManager();
 
   public static String TARGET = System.getenv("TARGET");
-  private static String NAILGUN = "nailgun_launcher/";
-  private static String STAGE1 = "stage1/";
+  private static String NAILGUN = "nailgun_launcher" + fSep;
+  private static String STAGE1 = "stage1" + fSep;
 
   @SuppressWarnings("unchecked")
   public static Object getBuild( Object context ) throws Throwable{
     BuildStage1Result res = buildStage1(
       (long) get(context, "cbtLastModified"),
       (long) get(context, "start"),
-      ((File) get(context, "cache")).toString() + "/",
+      ((File) get(context, "cache")).toString() + fSep,
       ((File) get(context, "cbtHome")).toString(),
-      ((File) get(context, "compatibilityTarget")).toString() + "/",
+      ((File) get(context, "compatibilityTarget")).toString() + fSep,
       new ClassLoaderCache(
         (HashMap) get(context, "persistentCache")
       ),
@@ -92,8 +95,8 @@ public class NailgunLauncher{
     // ---------------------
 
     String CBT_HOME = System.getenv("CBT_HOME");
-    String cache = CBT_HOME + "/cache/";
-    String compatibilityTarget = CBT_HOME + "/compatibility/" + TARGET;
+    String cache = CBT_HOME + fSep + "cache" + fSep;
+    String compatibilityTarget = CBT_HOME + fSep + "compatibility" + fSep+ TARGET;
     // copy cache, so that this thread has a consistent view despite other threads
     // changing their copies
     // replace again before returning, see below
@@ -101,8 +104,8 @@ public class NailgunLauncher{
       new HashMap<Object,Object>(classLoaderCacheHashMap)
     );
 
-    String nailgunTarget = CBT_HOME + "/" + NAILGUN + TARGET;
-    long nailgunLauncherLastModified = new File( nailgunTarget + "../classes.last-success" ).lastModified();
+    String nailgunTarget = CBT_HOME + fSep + NAILGUN + TARGET;
+    long nailgunLauncherLastModified = new File( nailgunTarget +  ".." + fSep + "classes.last-success" ).lastModified();
 
     File cwd = new File(args[1]);
     boolean loop = args[2].equals("0");
@@ -145,14 +148,14 @@ public class NailgunLauncher{
     final String compatibilityTarget, final ClassLoaderCache classLoaderCache, File cwd, boolean loop
   ) throws Throwable {
     _assert(TARGET != null, "environment variable TARGET not defined");
-    String nailgunSources = cbtHome + "/" + NAILGUN + "src/cbt";
-    String nailgunTarget = cbtHome + "/" + NAILGUN + TARGET;
-    String stage1Sources = cbtHome + "/" + STAGE1;
+    String nailgunSources = cbtHome + fSep + NAILGUN + "src" + fSep + "cbt";
+    String nailgunTarget = cbtHome + fSep + NAILGUN + TARGET;
+    String stage1Sources = cbtHome + fSep + STAGE1;
     String stage1Target = stage1Sources + TARGET;
-    String compatibilitySources = cbtHome + "/compatibility/src/cbt";
+    String compatibilitySources = cbtHome + fSep + "compatibility" + fSep + "src" + fSep + "cbt";
     String mavenCache = cache + "maven";
     String mavenUrl = "https://repo1.maven.org/maven2";
-    File loopFile = new File(cwd + "/target/.cbt-loop.tmp");
+    File loopFile = new File(cwd + fSep + "target" + fSep + ".cbt-loop.tmp");
     if(loop){
       loopFile.getParentFile().mkdirs();
     }
@@ -167,16 +170,16 @@ public class NailgunLauncher{
       }
     }
 
-    long nailgunLauncherLastModified = new File( nailgunTarget + "../classes.last-success" ).lastModified();
+    long nailgunLauncherLastModified = new File( nailgunTarget +  ".." + fSep + "classes.last-success" ).lastModified();
 
     long compatibilityLastModified;
     if(!compatibilityTarget.startsWith(cbtHome)){
-      compatibilityLastModified = new File( compatibilityTarget + "../classes.last-success" ).lastModified();
+      compatibilityLastModified = new File( compatibilityTarget + ".." + fSep + "classes.last-success" ).lastModified();
     } else {
       compatibilitySourceFiles = new ArrayList<File>();
       for( String d: new String[]{
         compatibilitySources,
-        cbtHome + "/libraries/interfaces/src/cbt/interfaces"
+        cbtHome + fSep + "libraries" + fSep + "interfaces" + fSep +"src" + fSep + "cbt" + fSep +"interfaces"
       } ){
         for( File f: new File(d).listFiles() ){
           if( f.isFile() && f.toString().endsWith(".java") ){
@@ -216,10 +219,10 @@ public class NailgunLauncher{
     stage1SourceFiles = new ArrayList<File>();
     for( String d: new String[]{
       stage1Sources,
-      cbtHome + "/libraries/reflect",
-      cbtHome + "/libraries/common-1",
-      cbtHome + "/libraries/common-1/src/cbt",
-      cbtHome + "/libraries/file"
+      cbtHome + fSep + "libraries" + fSep + "reflect",
+      cbtHome + fSep + "libraries" + fSep + "common-1",
+      cbtHome + fSep + "libraries" + fSep + "common-1" + fSep + "src" + fSep + "cbt",
+      cbtHome + fSep + "libraries" + fSep + "file"
     } ){
       for( File f: new File(d).listFiles() ){
         if( f.isFile() && (f.toString().endsWith(".scala") || f.toString().endsWith(".java")) ){

--- a/stage1/CbtPaths.scala
+++ b/stage1/CbtPaths.scala
@@ -1,17 +1,18 @@
 package cbt
 import java.io._
 case class CbtPaths(private val cbtHome: File, private val cache: File){
+  val fSep = File.separator 
   val userHome: File = new File(Option(System.getProperty("user.home")).get)
-  val nailgun: File = cbtHome ++ "/nailgun_launcher"
-  val stage1: File = cbtHome ++ "/stage1"
-  val stage2: File = cbtHome ++ "/stage2"
-  val mavenCache: File = cache ++ "/maven"
-  private val target = NailgunLauncher.TARGET.stripSuffix("/")
-  val stage1Target: File = stage1 ++ ("/" ++ target)
-  val stage2Target: File = stage2 ++ ("/" ++ target)
+  val nailgun: File = cbtHome ++ (fSep+"nailgun_launcher")
+  val stage1: File = cbtHome ++ (fSep+"stage1")
+  val stage2: File = cbtHome ++ (fSep+"stage2")
+  val mavenCache: File = cache ++ (fSep+"maven")
+  private val target = NailgunLauncher.TARGET.stripSuffix(fSep)
+  val stage1Target: File = stage1 ++ (fSep ++ target)
+  val stage2Target: File = stage2 ++ (fSep ++ target)
   val stage1StatusFile: File = stage1Target ++ ".last-success"
   val stage2StatusFile: File = stage2Target ++ ".last-success"
-  val compatibility: File = cbtHome ++ "/compatibility"
-  val nailgunTarget: File = nailgun ++ ("/" ++ target)
+  val compatibility: File = cbtHome ++ (fSep+"compatibility")
+  val nailgunTarget: File = nailgun ++ (fSep ++ target)
   val nailgunStatusFile: File = nailgunTarget ++ ".last-success"
 }

--- a/stage1/ClassPath.scala
+++ b/stage1/ClassPath.scala
@@ -24,7 +24,7 @@ case class ClassPath(files: Seq[File] = Seq()){
   def strings = files.map{
     f => f.string + (
       // using file extension instead of isDirectory for performance reasons
-      if( f.getName.endsWith(".jar") /* !f.isDirectory */ ) "" else "/"
+      if( f.getName.endsWith(".jar") /* !f.isDirectory */ ) "" else File.separator
     )
   }.sorted
 

--- a/stage1/Stage1.scala
+++ b/stage1/Stage1.scala
@@ -99,6 +99,20 @@ object Stage1{
 
     val cls = this.getClass.getClassLoader.loadClass("cbt.NailgunLauncher")
 
+    println("paths " + paths)
+      println("userHome: " + userHome)
+  println("nailgun: " + nailgun)
+  println("stage1: " + stage1)
+  println("stage2: " + stage2)
+  println("mavenCache: " + mavenCache)
+  println("stage1Target: " + stage1Target)
+  println("stage2Target: " + stage2Target)
+  println("stage1StatusFile: " + stage1StatusFile)
+  println("stage2StatusFile: " + stage2StatusFile)
+  println("compatibility:" + compatibility)
+  println("nailgunTarget: " + nailgunTarget)
+  println("nailgunStatusFile " + nailgunStatusFile)
+
     def _cbtDependencies = new CbtDependencies(
       (stage2Target++".last-success").lastModified,
       mavenCache, nailgunTarget, stage1Target, stage2Target,
@@ -125,11 +139,14 @@ object Stage1{
 
     logger.stage1(s"calling CbtDependency.classLoader")
 
-    assert(
+    println("buildStage1.compatibilityClasspath " + buildStage1.compatibilityClasspath)
+    println("cbtDependencies.compatibilityDependency.classpath.string " + cbtDependencies.compatibilityDependency.classpath.string)
+
+    /*assert(
       buildStage1.compatibilityClasspath === cbtDependencies.compatibilityDependency.classpath.string,
       "compatibility classpath different from NailgunLauncher"
-    )
-    assert(
+    )*/
+    /*assert(
       buildStage1.stage1Classpath === cbtDependencies.stage1Dependency.classpath.string,
       "stage1 classpath different from NailgunLauncher"
     )
@@ -140,11 +157,11 @@ object Stage1{
     assert(
       classLoaderCache.containsKey( cbtDependencies.stage1Dependency.classpath.string, cbtDependencies.stage1Dependency.lastModified ),
       "cbt unchanged, expected stage1 classloader to be cached"
-    )
+    )*/
 
     val stage2ClassLoader = cbtDependencies.stage2Dependency.classLoader
 
-    {
+    /*{
       // a few classloader sanity checks
       val compatibilityClassLoader =
         cbtDependencies.compatibilityDependency.classLoader
@@ -164,7 +181,9 @@ object Stage1{
         Stage0Lib.get(stage2ClassLoader.getParent,"parents").asInstanceOf[Seq[ClassLoader]].contains(stage1ClassLoader),
         stage1ClassLoader.toString ++ "\n\nis not contained in parents of\n\n" ++ stage2ClassLoader.toString
       )
-    }
+    }*/
+
+    println("load" + (stage2ClassLoader.loadClass("cbt.Stage2").getDeclaredMethods.mkString(" ")))
 
     ( stage2sourceFiles, stage2LastModified, stage2ClassLoader )
   }

--- a/stage1/Stage1.scala
+++ b/stage1/Stage1.scala
@@ -99,20 +99,6 @@ object Stage1{
 
     val cls = this.getClass.getClassLoader.loadClass("cbt.NailgunLauncher")
 
-    println("paths " + paths)
-      println("userHome: " + userHome)
-  println("nailgun: " + nailgun)
-  println("stage1: " + stage1)
-  println("stage2: " + stage2)
-  println("mavenCache: " + mavenCache)
-  println("stage1Target: " + stage1Target)
-  println("stage2Target: " + stage2Target)
-  println("stage1StatusFile: " + stage1StatusFile)
-  println("stage2StatusFile: " + stage2StatusFile)
-  println("compatibility:" + compatibility)
-  println("nailgunTarget: " + nailgunTarget)
-  println("nailgunStatusFile " + nailgunStatusFile)
-
     def _cbtDependencies = new CbtDependencies(
       (stage2Target++".last-success").lastModified,
       mavenCache, nailgunTarget, stage1Target, stage2Target,
@@ -139,14 +125,12 @@ object Stage1{
 
     logger.stage1(s"calling CbtDependency.classLoader")
 
-    println("buildStage1.compatibilityClasspath " + buildStage1.compatibilityClasspath)
-    println("cbtDependencies.compatibilityDependency.classpath.string " + cbtDependencies.compatibilityDependency.classpath.string)
-
-    /*assert(
+    assert(
       buildStage1.compatibilityClasspath === cbtDependencies.compatibilityDependency.classpath.string,
       "compatibility classpath different from NailgunLauncher"
-    )*/
-    /*assert(
+    )
+
+    assert(
       buildStage1.stage1Classpath === cbtDependencies.stage1Dependency.classpath.string,
       "stage1 classpath different from NailgunLauncher"
     )
@@ -157,11 +141,11 @@ object Stage1{
     assert(
       classLoaderCache.containsKey( cbtDependencies.stage1Dependency.classpath.string, cbtDependencies.stage1Dependency.lastModified ),
       "cbt unchanged, expected stage1 classloader to be cached"
-    )*/
+    )
 
     val stage2ClassLoader = cbtDependencies.stage2Dependency.classLoader
 
-    /*{
+    {
       // a few classloader sanity checks
       val compatibilityClassLoader =
         cbtDependencies.compatibilityDependency.classLoader
@@ -181,9 +165,7 @@ object Stage1{
         Stage0Lib.get(stage2ClassLoader.getParent,"parents").asInstanceOf[Seq[ClassLoader]].contains(stage1ClassLoader),
         stage1ClassLoader.toString ++ "\n\nis not contained in parents of\n\n" ++ stage2ClassLoader.toString
       )
-    }*/
-
-    println("load" + (stage2ClassLoader.loadClass("cbt.Stage2").getDeclaredMethods.mkString(" ")))
+    }
 
     ( stage2sourceFiles, stage2LastModified, stage2ClassLoader )
   }

--- a/stage2/ToolsTasks.scala
+++ b/stage2/ToolsTasks.scala
@@ -2,7 +2,8 @@ package cbt
 import java.net._
 import java.io.{Console=>_,_}
 import java.nio.file._
-class ToolsTasks(
+class
+ToolsTasks(
   lib: Lib,
   args: Seq[String],
   cwd: File,
@@ -139,6 +140,7 @@ import java.nio.file.*;
 import java.net.*;
 import java.security.*;
 import java.util.*;
+import java.util.regex.Matcher;
 import static cbt.Stage0Lib.*;
 import static cbt.NailgunLauncher.*;
 
@@ -163,7 +165,7 @@ public class EarlyDependencies{
   public EarlyDependencies(
     String mavenCache, String mavenUrl, ClassLoaderCache classLoaderCache, ClassLoader rootClassLoader
   ) throws Throwable {
-${files.map(d => s"""    String ${valName(d)}File = mavenCache + "${d.basePath(true)}.jar";""").mkString("\n")}
+${files.map(d => s"""    String ${valName(d)}File = mavenCache + pip("${d.basePath(true)}.jar");""").mkString("\n")}
 
 ${scalaDeps.map(d => s"""    download(new URL(mavenUrl + "${d.basePath(true)}.jar"), Paths.get(${valName(d)}File), "${d.jarSha1}");""").mkString("\n")}
 ${assignments.mkString("\n")}
@@ -178,6 +180,13 @@ ${assignments.mkString("\n")}
     scalaReflect_File = scalaReflect_${_scalaVersion}_File;
     sbtInterface_File = sbtInterface_${_sbtVersion}_File;
     compilerInterface_File = compilerInterface_${_sbtVersion}_File;
+  }
+
+  // Replaces slashes with backslashes, e.g. a/b/c becomes a\\b\\c on Windows
+  private String pip(String unixPath) {
+    // when replacing the path with \\ Java treats it like escape character,
+    // that's why we need Matcher.quoteReplacement
+    return unixPath.replaceAll("/", Matcher.quoteReplacement(File.separator));
   }
 }
 """


### PR DESCRIPTION
This PR fixes most of the issues with using CBT on Windows:
- cache strings are now *platform independent* as far as they can, by using `pip(unixPath: String)` (path-independent-path, just converts slashes to backslashes)
- batch script is now working properly and is *usable*

Some minor issues left:
- improve Nailgun support, `java.net.SocketException: Connection reset`
- time function
- nailgun log files are impossible to write to, when ng-server is up (`.. >> %nailgun_out% 2>> %nailgun_err%`)
- `eval` can't be used with single-quotes since CMD treats them specially... You can use double-quotes but then you can't use `String` literals 😄 