### PR TITLE
Classes with non-trivial constructors were made to be not considered as possible main classes

### DIFF
--- a/libraries/reflect/reflect.scala
+++ b/libraries/reflect/reflect.scala
@@ -164,12 +164,12 @@ trait Module {
   def typeStaticMethod[Arg, Result]( method: Method ): Option[StaticMethod[Arg, Result]] = {
     val m = method
     val instanceOption =
-      if ( m.isStatic ) Some(null)
+      if ( m.isStatic ) Some( null )
       else m.declaringClass.getConstructors.find( _.getParameterCount == 0 ).map( _.newInstance() ) // Dottydoc needs this. It's main method is not static.
     instanceOption.map( instance => StaticMethod(
       arg => m.invoke( instance, arg.asInstanceOf[AnyRef] ).asInstanceOf[Result],
       m
-    ))
+    ) )
   }
 
   def trapExitCodeOrValue[T]( result: => T, i: Int = 5 ): Either[ExitCode, T] = {

--- a/libraries/reflect/reflect.scala
+++ b/libraries/reflect/reflect.scala
@@ -130,7 +130,7 @@ trait Module {
   ): StaticMethod[Arg, Result] = {
     val m = cls.method( name, Arg.runtimeClass )
     assert( Result.runtimeClass.isAssignableFrom( m.returnType ) )
-    typeStaticMethod( m )
+    typeStaticMethod( m ).get // This will fail if None is returned.
   }
 
   def findStaticExitMethod[Arg: ClassTag](
@@ -158,18 +158,18 @@ trait Module {
             && m.name == name
             && m.parameterTypes.toList == List( Arg.runtimeClass )
             && Result.runtimeClass.isAssignableFrom( m.returnType ) ) )
-      .map( typeStaticMethod )
+      .flatMap( typeStaticMethod )
   }
 
-  def typeStaticMethod[Arg, Result]( method: Method ): StaticMethod[Arg, Result] = {
+  def typeStaticMethod[Arg, Result]( method: Method ): Option[StaticMethod[Arg, Result]] = {
     val m = method
-    val instance =
-      if ( m.isStatic ) null
-      else m.declaringClass.newInstance // Dottydoc needs this. It's main method is not static.
-    StaticMethod(
+    val instanceOption =
+      if ( m.isStatic ) Some(null)
+      else m.declaringClass.getConstructors.find( _.getParameterCount == 0 ).map( _.newInstance() ) // Dottydoc needs this. It's main method is not static.
+    instanceOption.map( instance => StaticMethod(
       arg => m.invoke( instance, arg.asInstanceOf[AnyRef] ).asInstanceOf[Result],
       m
-    )
+    ))
   }
 
   def trapExitCodeOrValue[T]( result: => T, i: Int = 5 ): Either[ExitCode, T] = {


### PR DESCRIPTION
Possible fix for #585. Classes with non-public or parameterized contructors were made to be not searched by the main class searcher. This leads to
- not failing when project contains such class (with non-public or parameterized constructor and ``def main(args: Array[String])`` at the same time);
- ignoring such classes when searching a main-class, in particular, not showing such classes when there are alternatives.

And, oh, I changed the signature of the ``typeStaticMethod``, but I hope I made it more correct (since, as far as I can see, you use -``OrFail`` suffix for those methods you are expecting to be easily failing).